### PR TITLE
Minor fixes

### DIFF
--- a/src/extension/src/extension.ts
+++ b/src/extension/src/extension.ts
@@ -182,14 +182,8 @@ class NeoContractDebugAdapterDescriptorFactory implements vscode.DebugAdapterDes
 			args.push("--log");
 		}
 
-		if (session.workspaceFolder)
-		{
-			return new vscode.DebugAdapterExecutable(cmd, args, { cwd: session.workspaceFolder.uri.fsPath });	
-		}
-		else
-		{
-			return new vscode.DebugAdapterExecutable(cmd, args);
-		}
+		const options = session.workspaceFolder ? { cwd: session.workspaceFolder.uri.fsPath } : {};
+		return new vscode.DebugAdapterExecutable(cmd, args, options);	
 	}
 }
 

--- a/src/extension/src/extension.ts
+++ b/src/extension/src/extension.ts
@@ -182,7 +182,14 @@ class NeoContractDebugAdapterDescriptorFactory implements vscode.DebugAdapterDes
 			args.push("--log");
 		}
 
-		return new vscode.DebugAdapterExecutable(cmd, args);
+		if (session.workspaceFolder)
+		{
+			return new vscode.DebugAdapterExecutable(cmd, args, { cwd: session.workspaceFolder.uri.fsPath });	
+		}
+		else
+		{
+			return new vscode.DebugAdapterExecutable(cmd, args);
+		}
 	}
 }
 

--- a/src/library/DebugSession.cs
+++ b/src/library/DebugSession.cs
@@ -194,8 +194,12 @@ namespace NeoDebug
                         };
                         frame.Line = sequencePoint.Start.line;
                         frame.Column = sequencePoint.Start.column;
-                        frame.EndLine = sequencePoint.End.line;
-                        frame.EndColumn = sequencePoint.End.column;
+
+                        if (sequencePoint.Start != sequencePoint.End)
+                        {
+                            frame.EndLine = sequencePoint.End.line;
+                            frame.EndColumn = sequencePoint.End.column;
+                        }
                     }
 
                     yield return frame;


### PR DESCRIPTION
As part of some long-lead python integration prototyping, found a few issues with neo-debugger:

* Launch the debug adapter in the workspaceFolder of the contract being debugged
* Resolve document paths that only match end portion of the path specified in avmdbgnfo file
* only emit stack frame end line/column info if it's different from start line/column
* Support empty parameter types
* encode string contract arguments as UTF-8 byte arrays if they don't parse as a big integer or NEO address

Note, since the release process for 1.0 has started, this PR will merge into the release/v1.0 branch. It will then be merged into master branch w/o further PR review