### PR TITLE
EmulatedStorage TryPut/TryDelete should be using index set

### DIFF
--- a/src/adapter/EmulatedStorage.cs
+++ b/src/adapter/EmulatedStorage.cs
@@ -96,7 +96,7 @@ namespace NeoDebug.Adapter
                 return false;
             }
 
-            storage.Add(key, (false, new StorageItem(value, constant)));
+            storage[key] = (false, new StorageItem(value, constant));
             return true;
         }
 
@@ -108,7 +108,7 @@ namespace NeoDebug.Adapter
                 return false;
             }
 
-            storage.Add(key, (true, default));
+            storage[key] = (true, default);
             return true;
         }
     }


### PR DESCRIPTION
Dictionary.Add [throws an exception](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.add?view=netcore-3.1#exceptions) if the key already exists. However, TryPut/TryDelete should overwrite any existing value in the dictionary. This PR switches TryPut/TryDelete to use Item property setter (aka index set) instead of Add.

fixes #20 