### PR TITLE
EmulatedStorage TryPut/TryDelete should be using index set not add

### DIFF
--- a/src/adapter/EmulatedStorage.cs
+++ b/src/adapter/EmulatedStorage.cs
@@ -96,7 +96,7 @@ namespace NeoDebug.Adapter
                 return false;
             }
 
-            storage.Add(key, (false, new StorageItem(value, constant)));
+            storage[key] = (false, new StorageItem(value, constant));
             return true;
         }
 
@@ -108,7 +108,7 @@ namespace NeoDebug.Adapter
                 return false;
             }
 
-            storage.Add(key, (true, default));
+            storage[key] = (true, default);
             return true;
         }
     }

--- a/src/extension/CHANGELOG.md
+++ b/src/extension/CHANGELOG.md
@@ -13,6 +13,12 @@ will not have contiguous patch numbers. Initial major and minor releases will be
 in this file without a patch number. Patch version will be included for bug fix releases, but
 may not exactly match a publicly released version.
 
+## Unreleased
+
+### Fixed
+
+- Adding item with the non-unique key to emulated storage [#20](https://github.com/neo-project/neo-debugger/issues/20)
+
 ## [1.0] - 2020-02-06
 
 ### Added


### PR DESCRIPTION
Dictionary.Add [throws an exception](https://docs.microsoft.com/en-us/dotnet/api/system.collections.generic.dictionary-2.add?view=netcore-3.1#exceptions) if the key already exists. However, TryPut/TryDelete should overwrite any existing value in the dictionary. This PR switches TryPut/TryDelete to use Item property setter (aka index set) instead of Add.

fixes #20 