### PR TITLE
Improve avmdbgnfo document resolution

### DIFF
--- a/src/extension/CHANGELOG.md
+++ b/src/extension/CHANGELOG.md
@@ -18,6 +18,7 @@ may not exactly match a publicly released version.
 ### Fixed
 
 - Adding item with the non-unique key to emulated storage [#20](https://github.com/neo-project/neo-debugger/issues/20)
+- Improve document path resolution [#24](https://github.com/neo-project/neo-debugger/issues/24)
 
 ## [1.0] - 2020-02-06
 


### PR DESCRIPTION
Adds DebugInfoParser.DocumentResolver class that improves avmdbgnfo document resolution in two ways:

1. Look in current working directory for a matching source document
2. Remember folder mappings for matched source documents when mapping additional documents

fixes #24 