### PR TITLE
Only show disassembly command on debug toolbar menu when debugging neo contract

### DIFF
--- a/src/extension/package.json
+++ b/src/extension/package.json
@@ -314,7 +314,8 @@
         "menus": {
             "debug/toolBar": [
                 {
-                    "command": "neo-debugger.toggleDebugView"
+                    "command": "neo-debugger.toggleDebugView",
+                    "when": "debugType == 'neo-contract'"
                 }
             ]
         },


### PR DESCRIPTION
Fixes #44

Added `when` clause to `toggleDebugView` command on `debug/toolBar` menu so that the menu item is only shown when debugging neo-contracts

Note, I am going to pull this change into master w/o review after it is merged int release/v1.1 branch