### PR TITLE
add comment for overloaded NeoVM 2 opcodes

### DIFF
--- a/src/adapter2/Extensions/InstructionExtensions.cs
+++ b/src/adapter2/Extensions/InstructionExtensions.cs
@@ -41,6 +41,12 @@ namespace NeoDebug
         {
             switch (@this.OpCode)
             {
+                case OpCode.PUSH0:
+                case OpCode.PUSHF:
+                    return "PUSH0 and PUSHF use the same opcode value";
+                case OpCode.PUSH1:
+                case OpCode.PUSHT:
+                    return "PUSH1 and PUSHT use the same opcode value";
                 case OpCode opCode when opCode >= OpCode.PUSHBYTES1 && opCode <= OpCode.PUSHBYTES75:
                     {
                         return Encoding.UTF8.GetString(@this.Operand.Span);

--- a/src/adapter2/Extensions/InstructionExtensions.cs
+++ b/src/adapter2/Extensions/InstructionExtensions.cs
@@ -42,10 +42,8 @@ namespace NeoDebug
             switch (@this.OpCode)
             {
                 case OpCode.PUSH0:
-                case OpCode.PUSHF:
                     return "PUSH0 and PUSHF use the same opcode value";
                 case OpCode.PUSH1:
-                case OpCode.PUSHT:
                     return "PUSH1 and PUSHT use the same opcode value";
                 case OpCode opCode when opCode >= OpCode.PUSHBYTES1 && opCode <= OpCode.PUSHBYTES75:
                     {


### PR DESCRIPTION
PUSH0/PUSHF and PUSH1/PUSHT share opcode values. This change adds a comment to those opcodes to remind the user of the overloaded opcode usage

Fixes #46 for master branch. PR #59 fixes for release/v1.1 branch