### PR TITLE
Correctly generate neo 3 debug launch config 

### DIFF
--- a/src/extension/src/extension.ts
+++ b/src/extension/src/extension.ts
@@ -110,6 +110,9 @@ class NeoContractDebugConfigurationProvider implements vscode.DebugConfiguration
                 program: programPath && folder 
                     ? join("${workspaceFolder}", relative(folder.uri.fsPath, programPath)) 
                     : "${workspaceFolder}",
+                operation: (programPath ? extname(programPath) : "") === ".nef" 
+                    ? "" 
+                    : undefined,
                 args: [],
                 storage: [],
                 runtime: {

--- a/src/extension/src/extension.ts
+++ b/src/extension/src/extension.ts
@@ -109,9 +109,9 @@ class NeoContractDebugConfigurationProvider implements vscode.DebugConfiguration
                 request: "launch",
                 program: programPath && folder 
                     ? join("${workspaceFolder}", relative(folder.uri.fsPath, programPath)) 
-                    : "${workspaceFolder}",
+                    : "${workspaceFolder}/<insert path to contract here>",
                 operation: (programPath ? extname(programPath) : "") === ".nef" 
-                    ? "" 
+                    ? "<insert operation here>" 
                     : undefined,
                 args: [],
                 storage: [],

--- a/src/extension/src/extension.ts
+++ b/src/extension/src/extension.ts
@@ -122,7 +122,7 @@ class NeoContractDebugConfigurationProvider implements vscode.DebugConfiguration
         
         if (folder)
         {
-            var neoVmFiles = await vscode.workspace.findFiles(new vscode.RelativePattern(folder, "**/*.{avm,nvm}"));
+            var neoVmFiles = await vscode.workspace.findFiles(new vscode.RelativePattern(folder, "**/*.{avm,nef}"));
             if (neoVmFiles.length > 0) {
                 return neoVmFiles.map(f => createConfig(f.fsPath));
             }


### PR DESCRIPTION
debugger extension wasn't finding neo 3 contracts correctly after neo 3 extension was changed from `.nvm` to `.nef`. 

fixes #63 

Also updates the debug config provider to emit an `operation` property for neo3 contracts