### PR TITLE
Exception breakpoint Support

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning">
-      <Version>3.1.91</Version>
+      <Version>3.2.31</Version>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>

--- a/eng/azure-ci.yml
+++ b/eng/azure-ci.yml
@@ -65,7 +65,7 @@ steps:
 - task: Npm@1
   displayName: 'npm install'
   inputs:
-    command: 'install'
+    command: 'ci'
     workingDir: './src/extension' 
 
 - task: Npm@1

--- a/src/adapter2/neodebug-2-adapter.csproj
+++ b/src/adapter2/neodebug-2-adapter.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Neo.Fx" Version="1.0.2" />
     <PackageReference Include="Neo.Fx.RocksDb" Version="1.0.2" />
 
-    <PackageReference Include="Microsoft.VisualStudio.Shared.VsCodeDebugProtocol" Version="16.6.40406.1">
+    <PackageReference Include="Microsoft.VisualStudio.Shared.VsCodeDebugProtocol" Version="16.7.40526.2">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />

--- a/src/adapter3/BreakpointManager.cs
+++ b/src/adapter3/BreakpointManager.cs
@@ -48,7 +48,7 @@ namespace NeoDebug.Neo3
                     .Where(t => t.sp.PathEquals(t.d, source.Path))
                     .Select(t => t.sp)
                     .ToImmutableList();
-                    
+
                 foreach (var sbp in sourceBreakpoints)
                 {
                     yield return new Breakpoint()

--- a/src/adapter3/BreakpointManager.cs
+++ b/src/adapter3/BreakpointManager.cs
@@ -115,7 +115,8 @@ namespace NeoDebug.Neo3
             return breakpoints;
         }
 
-        public bool CheckBreakpoint(UInt160 scriptHash, int instructionPointer)
-            => GetBreakpoints(scriptHash).Contains(instructionPointer);
+        public bool CheckBreakpoint(UInt160 scriptHash, int? instructionPointer)
+            => instructionPointer.HasValue
+                && GetBreakpoints(scriptHash).Contains(instructionPointer.Value);
     }
 }

--- a/src/adapter3/DebugAdapter.cs
+++ b/src/adapter3/DebugAdapter.cs
@@ -336,6 +336,5 @@ namespace NeoDebug.Neo3
                 throw new ProtocolException(ex.Message, ex);
             }
         }
-
     }
 }

--- a/src/adapter3/DebugAdapter.cs
+++ b/src/adapter3/DebugAdapter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using Microsoft.VisualStudio.Shared.VSCodeDebugProtocol;
 using Microsoft.VisualStudio.Shared.VSCodeDebugProtocol.Messages;
@@ -11,14 +12,14 @@ namespace NeoDebug.Neo3
                                                           Action<DebugEvent> sendEvent,
                                                           DebugView defaultDebugView);
 
-        class DebugViewRequest : DebugRequest<DebugViewArguments>
+        private class DebugViewRequest : DebugRequest<DebugViewArguments>
         {
             public DebugViewRequest() : base("debugview")
             {
             }
         }
 
-        class DebugViewArguments : DebugRequestArguments
+        private class DebugViewArguments : DebugRequestArguments
         {
             [Newtonsoft.Json.JsonProperty("debugView")]
             public string DebugView { get; set; } = string.Empty;
@@ -42,10 +43,7 @@ namespace NeoDebug.Neo3
             InitializeProtocolClient(@in, @out);
             Protocol.LogMessage += (sender, args) => this.logger(args.Category, args.Message);
 
-            Protocol.RegisterRequestType<DebugViewRequest, DebugViewArguments>(a =>
-            {
-                HandleDebugViewRequest(a.Arguments);
-            });
+            Protocol.RegisterRequestType<DebugViewRequest, DebugViewArguments>(a => HandleDebugViewRequest(a.Arguments));
         }
 
         public void Run()
@@ -53,7 +51,7 @@ namespace NeoDebug.Neo3
             Protocol.Run();
         }
 
-        void Log(string message, LogCategory category = LogCategory.DebugAdapterOutput)
+        private void Log(string message, LogCategory category = LogCategory.DebugAdapterOutput)
         {
             logger(category, message);
         }
@@ -65,6 +63,18 @@ namespace NeoDebug.Neo3
             return new InitializeResponse()
             {
                 SupportsEvaluateForHovers = true,
+                SupportsExceptionInfoRequest = true,
+                ExceptionBreakpointFilters = new List<ExceptionBreakpointsFilter>
+                {
+                    new ExceptionBreakpointsFilter("caught", "Caught Exceptions")
+                    {
+                        Default = false
+                    },
+                    new ExceptionBreakpointsFilter("uncaught", "Uncaught Exceptions")
+                    {
+                        Default = true
+                    }
+                }
             };
         }
 
@@ -90,7 +100,7 @@ namespace NeoDebug.Neo3
             }
         }
 
-        void HandleDebugViewRequest(DebugViewArguments arguments)
+        private void HandleDebugViewRequest(DebugViewArguments arguments)
         {
             try
             {
@@ -114,6 +124,25 @@ namespace NeoDebug.Neo3
         protected override SetExceptionBreakpointsResponse HandleSetExceptionBreakpointsRequest(SetExceptionBreakpointsArguments arguments)
         {
             return new SetExceptionBreakpointsResponse();
+        }
+
+        protected override ExceptionInfoResponse HandleExceptionInfoRequest(ExceptionInfoArguments arguments)
+        {
+            try
+            {
+                if (session == null) throw new InvalidOperationException();
+                var exceptionInfo = session.GetExceptionInfo();
+
+                return new ExceptionInfoResponse()
+                {
+                    Description = exceptionInfo
+                };
+            }
+            catch (Exception ex)
+            {
+                Log(ex.Message, LogCategory.DebugAdapterOutput);
+                throw new ProtocolException(ex.Message, ex);
+            }
         }
 
         protected override SourceResponse HandleSourceRequest(SourceArguments arguments)

--- a/src/adapter3/DebugAdapter.cs
+++ b/src/adapter3/DebugAdapter.cs
@@ -66,11 +66,15 @@ namespace NeoDebug.Neo3
                 SupportsExceptionInfoRequest = true,
                 ExceptionBreakpointFilters = new List<ExceptionBreakpointsFilter>
                 {
-                    new ExceptionBreakpointsFilter("caught", "Caught Exceptions")
+                    new ExceptionBreakpointsFilter(
+                        DebugSession.CAUGHT_EXCEPTION_FILTER,
+                        "Caught Exceptions")
                     {
                         Default = false
                     },
-                    new ExceptionBreakpointsFilter("uncaught", "Uncaught Exceptions")
+                    new ExceptionBreakpointsFilter(
+                        DebugSession.UNCAUGHT_EXCEPTION_FILTER,
+                        "Uncaught Exceptions")
                     {
                         Default = true
                     }

--- a/src/adapter3/DebugAdapter.cs
+++ b/src/adapter3/DebugAdapter.cs
@@ -121,11 +121,6 @@ namespace NeoDebug.Neo3
             return new DisconnectResponse();
         }
 
-        protected override SetExceptionBreakpointsResponse HandleSetExceptionBreakpointsRequest(SetExceptionBreakpointsArguments arguments)
-        {
-            return new SetExceptionBreakpointsResponse();
-        }
-
         protected override ExceptionInfoResponse HandleExceptionInfoRequest(ExceptionInfoArguments arguments)
         {
             try
@@ -325,5 +320,22 @@ namespace NeoDebug.Neo3
                 throw new ProtocolException(ex.Message, ex);
             }
         }
+
+        protected override SetExceptionBreakpointsResponse HandleSetExceptionBreakpointsRequest(SetExceptionBreakpointsArguments arguments)
+        {
+            try
+            {
+                if (session == null) throw new InvalidOperationException();
+
+                session.SetExceptionBreakpoints(arguments.Filters);
+                return new SetExceptionBreakpointsResponse();
+            }
+            catch (Exception ex)
+            {
+                Log(ex.Message, LogCategory.DebugAdapterOutput);
+                throw new ProtocolException(ex.Message, ex);
+            }
+        }
+
     }
 }

--- a/src/adapter3/DebugApplicationEngine.cs
+++ b/src/adapter3/DebugApplicationEngine.cs
@@ -49,7 +49,7 @@ namespace NeoDebug.Neo3
             this.witnessChecker = witnessChecker;
             this.blockHashMap = storeView.Blocks.Find()
                 .ToDictionary(
-                    t => t.Value.Index, 
+                    t => t.Value.Index,
                     t => t.Value.Hash == t.Key ? t.Key : throw new Exception("invalid hash"));
         }
 
@@ -97,7 +97,7 @@ namespace NeoDebug.Neo3
             NotifyEventArgs args = new NotifyEventArgs(
                 engine.ScriptContainer,
                 engine.CurrentScriptHash,
-                Neo.Utility.StrictUTF8.GetString(eventName), 
+                Neo.Utility.StrictUTF8.GetString(eventName),
                 (NeoArray)state.DeepCopy());
             engine.DebugNotify?.Invoke(engine, args);
 
@@ -128,7 +128,7 @@ namespace NeoDebug.Neo3
         {
             Debug.Assert(paramDescriptors.Count == 1);
 
-            var indexOrHash = (byte[])engine.Convert(engine.Pop(), paramDescriptors[0]); 
+            var indexOrHash = (byte[])engine.Convert(engine.Pop(), paramDescriptors[0]);
             var hash = engine.GetBlockHash(indexOrHash);
 
             if (hash is null) return StackItem.Null;

--- a/src/adapter3/DebugApplicationEngine.cs
+++ b/src/adapter3/DebugApplicationEngine.cs
@@ -137,7 +137,7 @@ namespace NeoDebug.Neo3
             NotifyEventArgs args = new NotifyEventArgs(
                 engine.ScriptContainer,
                 engine.CurrentScriptHash,
-                Neo.Utility.StrictUTF8.GetString(eventName),
+                eventName.ToStrictUTF8String(),
                 (NeoArray)state.DeepCopy());
             engine.DebugNotify?.Invoke(engine, args);
 
@@ -155,7 +155,7 @@ namespace NeoDebug.Neo3
             var args = new LogEventArgs(
                 engine.ScriptContainer,
                 engine.CurrentScriptHash,
-                Neo.Utility.StrictUTF8.GetString(state));
+                state.ToStrictUTF8String());
             engine.DebugLog?.Invoke(engine, args);
 
             engine.RuntimeLog(state);

--- a/src/adapter3/DebugApplicationEngine.cs
+++ b/src/adapter3/DebugApplicationEngine.cs
@@ -11,6 +11,7 @@ using NeoArray = Neo.VM.Types.Array;
 using Neo;
 using System.Numerics;
 using System.Linq;
+using Neo.VM;
 
 namespace NeoDebug.Neo3
 {
@@ -54,6 +55,22 @@ namespace NeoDebug.Neo3
         }
 
         public void ExecuteInstruction() => ExecuteNext();
+
+        public bool CatchBlockOnStack()
+        {
+            foreach (var executionContext in InvocationStack)
+            {
+                foreach (var tryContext in executionContext.TryStack ?? Enumerable.Empty<ExceptionHandlingContext>())
+                {
+                    if (tryContext.HasCatch)
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            return false;
+        }
 
         protected override void OnSysCall(uint methodHash)
         {

--- a/src/adapter3/DebugSession.cs
+++ b/src/adapter3/DebugSession.cs
@@ -25,7 +25,7 @@ namespace NeoDebug.Neo3
         private readonly DisassemblyManager disassemblyManager;
         private readonly VariableManager variableManager = new VariableManager();
         private readonly BreakpointManager breakpointManager;
-        
+
         public DebugSession(DebugApplicationEngine engine, IStore store, IReadOnlyList<string> returnTypes, Action<DebugEvent> sendEvent, DebugView defaultDebugView)
         {
             this.engine = engine;
@@ -280,7 +280,7 @@ namespace NeoDebug.Neo3
                 {
                     return result;
                 }
-                
+
                 if (TryEvaluateSlot(context.LocalVariables, method.Variables, out result))
                 {
                     return result;
@@ -334,10 +334,10 @@ namespace NeoDebug.Neo3
                 {
                     var newItem = item switch
                     {
-                        Neo.VM.Types.Buffer buffer => (int)buffer.InnerBuffer[index], 
+                        Neo.VM.Types.Buffer buffer => (int)buffer.InnerBuffer[index],
                         Neo.VM.Types.ByteString byteString => (int)byteString.GetSpan()[index],
                         Neo.VM.Types.Array array => array[index],
-                       _ => throw new InvalidOperationException(),
+                        _ => throw new InvalidOperationException(),
                     };
 
                     return ProcessRemaining(newItem, string.Empty, remaining.Slice(bracketIndex + 1));
@@ -439,7 +439,7 @@ namespace NeoDebug.Neo3
             {
                 engine.ExecuteInstruction();
 
-                if (engine.CurrentContext != null && 
+                if (engine.CurrentContext != null &&
                     breakpointManager.CheckBreakpoint(engine.CurrentScriptHash, engine.CurrentContext.InstructionPointer))
                 {
                     stopReason = StoppedEvent.ReasonValue.Breakpoint;
@@ -457,7 +457,7 @@ namespace NeoDebug.Neo3
 
             bool CheckSequencePoint()
             {
-                if (engine.CurrentContext != null) 
+                if (engine.CurrentContext != null)
                 {
                     var ip = engine.CurrentContext.InstructionPointer;
                     if (TryGetDebugInfo(engine.CurrentScriptHash, out var info))
@@ -473,7 +473,7 @@ namespace NeoDebug.Neo3
                     }
                 }
                 return false;
-            } 
+            }
         }
 
         public void Continue()
@@ -482,7 +482,7 @@ namespace NeoDebug.Neo3
             {
                 engine.ExecuteInstruction();
 
-                if (engine.CurrentContext != null && 
+                if (engine.CurrentContext != null &&
                     breakpointManager.CheckBreakpoint(engine.CurrentScriptHash, engine.CurrentContext.InstructionPointer))
                 {
                     break;

--- a/src/adapter3/DebugSession.cs
+++ b/src/adapter3/DebugSession.cs
@@ -363,6 +363,12 @@ namespace NeoDebug.Neo3
             return breakpointManager.SetBreakpoints(source, sourceBreakpoints);
         }
 
+        public void SetExceptionBreakpoints(IReadOnlyList<string> filters)
+        {
+            
+        }
+
+
         public string GetExceptionInfo()
         {
             return string.Empty;

--- a/src/adapter3/DebugSession.cs
+++ b/src/adapter3/DebugSession.cs
@@ -434,17 +434,17 @@ namespace NeoDebug.Neo3
                     return;
                 }
 
+                engine.ExecuteInstruction();
+
                 if (engine.CurrentContext?.CurrentInstruction.OpCode == OpCode.THROW)
                 {
-                    var handled = engine.CatchBlockOnStack();
-                    if (!handled)
+                    // var handled = engine.CatchBlockOnStack();
+                    // if (!handled)
                     {
                         FireStoppedEvent(StoppedEvent.ReasonValue.Exception);
                         return;
                     }
                 }
-
-                engine.ExecuteInstruction();
 
                 if (breakpointManager.CheckBreakpoint(engine.CurrentScriptHash, engine.CurrentContext?.InstructionPointer))
                 {

--- a/src/adapter3/DebugSession.cs
+++ b/src/adapter3/DebugSession.cs
@@ -438,8 +438,12 @@ namespace NeoDebug.Neo3
 
                 if (engine.CurrentContext?.CurrentInstruction.OpCode == OpCode.THROW)
                 {
-                    FireStoppedEvent(StoppedEvent.ReasonValue.Exception);
-                    return;
+                    var handled = engine.CatchBlockOnStack();
+                    if (!handled)
+                    {
+                        FireStoppedEvent(StoppedEvent.ReasonValue.Exception);
+                        return;
+                    }
                 }
 
                 engine.ExecuteInstruction();

--- a/src/adapter3/DebugSession.cs
+++ b/src/adapter3/DebugSession.cs
@@ -145,6 +145,7 @@ namespace NeoDebug.Neo3
                         Path = disassembly.Name,
                     };
                     frame.Line = line; //index == 0 ? line : line - 1;   
+                    frame.Column = 1;
                 }
                 else
                 {

--- a/src/adapter3/DebugSession.cs
+++ b/src/adapter3/DebugSession.cs
@@ -363,6 +363,11 @@ namespace NeoDebug.Neo3
             return breakpointManager.SetBreakpoints(source, sourceBreakpoints);
         }
 
+        public string GetExceptionInfo()
+        {
+            return string.Empty;
+        }
+
         public void SetDebugView(DebugView debugView)
         {
             var original = disassemblyView;

--- a/src/adapter3/DisassemblyManager.cs
+++ b/src/adapter3/DisassemblyManager.cs
@@ -200,11 +200,13 @@ namespace NeoDebug.Neo3
                 case OpCode.PUSHDATA2:
                 case OpCode.PUSHDATA4:
                     {
+                        var text = Encoding.UTF8.GetString(instruction.Operand.Span)
+                            .Replace("\r", "\"\\r\"").Replace("\n", "\"\\n\"");
                         if (instruction.Operand.Length == 20)
                         {
-                            return $"as script hash: {new UInt160(instruction.Operand.Span)}, as text: {Encoding.UTF8.GetString(instruction.Operand.Span)}";
+                            return $"as script hash: {new UInt160(instruction.Operand.Span)}, as text: \"{text}\"";
                         }
-                        return $"as text: {Encoding.UTF8.GetString(instruction.Operand.Span)}";
+                        return $"as text: \"{text}\"";
                     }
                 case OpCode.SYSCALL:
                     return sysCallNames.TryGetValue(instruction.TokenU32, out var name)

--- a/src/adapter3/DisassemblyManager.cs
+++ b/src/adapter3/DisassemblyManager.cs
@@ -54,7 +54,7 @@ namespace NeoDebug.Neo3
             this.tryGetDebugInfo = tryGetDebugInfo;
         }
 
-        public Disassembly GetDisassembly(Script script, DebugInfo? debugInfo) 
+        public Disassembly GetDisassembly(Script script, DebugInfo? debugInfo)
             => disassemblies.GetOrAdd(script.GetHashCode(), sourceRef => ToDisassembly(sourceRef, script, debugInfo));
 
         public bool TryGetDisassembly(UInt160 scriptHash, out Disassembly disassembly)
@@ -70,7 +70,7 @@ namespace NeoDebug.Neo3
             return false;
         }
 
-        public bool TryGetDisassembly(int sourceRef, out Disassembly disassembly) 
+        public bool TryGetDisassembly(int sourceRef, out Disassembly disassembly)
             => disassemblies.TryGetValue(sourceRef, out disassembly);
 
         static Disassembly ToDisassembly(int sourceRef, Script script, DebugInfo? debugInfo)

--- a/src/adapter3/Extensions.cs
+++ b/src/adapter3/Extensions.cs
@@ -18,7 +18,7 @@ namespace NeoDebug.Neo3
         public static bool StartsWith<T>(this ReadOnlyMemory<T> @this, ReadOnlySpan<T> value)
             where T : IEquatable<T>
         {
-            return @this.Length >= value.Length 
+            return @this.Length >= value.Length
                 && @this.Slice(0, value.Length).Span.SequenceEqual(value);
         }
 
@@ -106,7 +106,7 @@ namespace NeoDebug.Neo3
                 {
                     Neo.VM.Types.Boolean _ => item.GetBoolean(),
                     // Neo.VM.Types.Buffer buffer => "Buffer",
-                    Neo.VM.Types.ByteString byteString => byteString.GetSpan().ToHexString(), 
+                    Neo.VM.Types.ByteString byteString => byteString.GetSpan().ToHexString(),
                     Neo.VM.Types.Integer @int => @int.GetInteger().ToString(),
                     // Neo.VM.Types.InteropInterface _ => MakeVariable("InteropInterface"),
                     // Neo.VM.Types.Map _ => MakeVariable("Map"),
@@ -126,7 +126,7 @@ namespace NeoDebug.Neo3
         {
             @this.EvaluateName = prefix + @this.Name;
             return @this;
-        }        
+        }
 
         public static EvaluateResponse ToEvaluateResponse(this Variable @this)
         {
@@ -148,17 +148,17 @@ namespace NeoDebug.Neo3
             return typeHint switch
             {
                 "Boolean" => item.GetBoolean().ToString(),
-                "Integer" => item.IsNull ? "0" : 
+                "Integer" => item.IsNull ? "0" :
                         ((Neo.VM.Types.Integer)item.ConvertTo(StackItemType.Integer)).GetInteger().ToString(),
-                "String" => item.IsNull ? "<null>" : 
+                "String" => item.IsNull ? "<null>" :
                         Encoding.UTF8.GetString(((ByteString)item.ConvertTo(StackItemType.ByteString)).GetSpan()),
                 "HexString" => ToHexString(item),
                 "ByteArray" => ToHexString(item),
                 _ => null
             };
 
-            static string ToHexString(StackItem item) => item.IsNull 
-                ? "<null>" 
+            static string ToHexString(StackItem item) => item.IsNull
+                ? "<null>"
                 : ((ByteString)item.ConvertTo(StackItemType.ByteString)).GetSpan().ToHexString();
         }
 
@@ -166,7 +166,7 @@ namespace NeoDebug.Neo3
         {
             if (typeHint == "ByteArray")
             {
-                if (item.IsNull) 
+                if (item.IsNull)
                 {
                     return MakeVariable("<null>", "ByteArray");
                 }

--- a/src/adapter3/IDebugSession.cs
+++ b/src/adapter3/IDebugSession.cs
@@ -7,6 +7,7 @@ namespace NeoDebug.Neo3
     {
         void Continue();
         EvaluateResponse Evaluate(EvaluateArguments args);
+        string GetExceptionInfo();
         IEnumerable<Scope> GetScopes(ScopesArguments args);
         SourceResponse GetSource(SourceArguments arguments);
         IEnumerable<StackFrame> GetStackFrames(StackTraceArguments args);

--- a/src/adapter3/IDebugSession.cs
+++ b/src/adapter3/IDebugSession.cs
@@ -15,6 +15,7 @@ namespace NeoDebug.Neo3
         IEnumerable<Variable> GetVariables(VariablesArguments args);
         IEnumerable<Breakpoint> SetBreakpoints(Source source, IReadOnlyList<SourceBreakpoint> sourceBreakpoints);
         void SetDebugView(DebugView debugView);
+        void SetExceptionBreakpoints(IReadOnlyList<string> filters);
         void Start();
         void StepIn();
         void StepOut();

--- a/src/adapter3/LaunchConfigParser.cs
+++ b/src/adapter3/LaunchConfigParser.cs
@@ -55,7 +55,7 @@ namespace NeoDebug.Neo3
                 Version = 0,
                 Nonce = (uint)(new Random()).Next(),
                 Script = invokeScript,
-                Signers = new[]{ new Signer() { Account = UInt160.Zero } },
+                Signers = new[] { new Signer() { Account = UInt160.Zero } },
                 ValidUntilBlock = Transaction.MaxValidUntilBlockIncrement,
                 Attributes = Array.Empty<TransactionAttribute>(),
                 Witnesses = Array.Empty<Witness>()
@@ -119,7 +119,7 @@ namespace NeoDebug.Neo3
 
         static byte[] CreateLaunchScript(UInt160 scriptHash, Dictionary<string, JToken> config)
         {
-            var operation = config.TryGetValue("operation", out var op) 
+            var operation = config.TryGetValue("operation", out var op)
                 ? op.Value<string>() : throw new InvalidDataException("missing operation config");
 
             using var builder = new ScriptBuilder();
@@ -138,7 +138,7 @@ namespace NeoDebug.Neo3
                 }
                 while (Directory.Exists(checkpointTempPath));
 
-                var cleanup = AnonymousDisposable.Create(() => 
+                var cleanup = AnonymousDisposable.Create(() =>
                 {
                     if (Directory.Exists(checkpointTempPath))
                     {
@@ -283,7 +283,7 @@ namespace NeoDebug.Neo3
             {
                 var arg = ContractParameterParser.ParseStringParam(token?.Value<string>() ?? string.Empty);
 
-                return arg.Type switch 
+                return arg.Type switch
                 {
                     ContractParameterType.Hash160 => ((UInt160)arg.Value).ToArray(),
                     ContractParameterType.Integer => ((BigInteger)arg.Value).ToByteArray(),

--- a/src/adapter3/Models/DebugInfo.Event.cs
+++ b/src/adapter3/Models/DebugInfo.Event.cs
@@ -12,7 +12,7 @@ namespace NeoDebug.Neo3
             public string Id { get; set; } = string.Empty;
             public string Namespace { get; set; } = string.Empty;
             public string Name { get; set; } = string.Empty;
-            public IReadOnlyList<(string Name, string Type)> Parameters { get; set; } 
+            public IReadOnlyList<(string Name, string Type)> Parameters { get; set; }
                 = ImmutableList<(string, string)>.Empty;
 
             public int Size => Id.GetVarSize()

--- a/src/adapter3/Models/DebugInfo.Method.cs
+++ b/src/adapter3/Models/DebugInfo.Method.cs
@@ -14,11 +14,11 @@ namespace NeoDebug.Neo3
             public string Name { get; set; } = string.Empty;
             public (int Start, int End) Range { get; set; }
             public string ReturnType { get; set; } = string.Empty;
-            public IReadOnlyList<(string Name, string Type)> Parameters { get; set; } 
+            public IReadOnlyList<(string Name, string Type)> Parameters { get; set; }
                 = ImmutableList<(string, string)>.Empty;
-            public IReadOnlyList<(string Name, string Type)> Variables { get; set; } 
+            public IReadOnlyList<(string Name, string Type)> Variables { get; set; }
                 = ImmutableList<(string, string)>.Empty;
-            public IReadOnlyList<SequencePoint> SequencePoints { get; set; } 
+            public IReadOnlyList<SequencePoint> SequencePoints { get; set; }
                 = ImmutableList<SequencePoint>.Empty;
 
             public int Size => Id.GetVarSize()

--- a/src/adapter3/Models/DebugInfo.Method.cs
+++ b/src/adapter3/Models/DebugInfo.Method.cs
@@ -25,7 +25,7 @@ namespace NeoDebug.Neo3
                 + Namespace.GetVarSize()
                 + Name.GetVarSize()
                 + ReturnType.GetVarSize()
-                + sizeof(int) * 2
+                + (sizeof(int) * 2)
                 + SizeTypes(Parameters)
                 + SizeTypes(Variables)
                 + SequencePoints.GetVarSize();
@@ -54,7 +54,7 @@ namespace NeoDebug.Neo3
                 writer.Write(Range.End);
                 WriteTypes(writer, Parameters);
                 WriteTypes(writer, Variables);
-                writer.Write<SequencePoint>(SequencePoints);
+                writer.Write(SequencePoints);
             }
         }
     }

--- a/src/adapter3/Models/DebugInfoParser.cs
+++ b/src/adapter3/Models/DebugInfoParser.cs
@@ -117,7 +117,9 @@ namespace NeoDebug.Neo3
                 var (ns, name) = SplitComma(token.Value<string>("name"));
                 var @params = token["params"].Select(t => SplitComma(t.Value<string>()));
                 var variables = token["variables"].Select(t => SplitComma(t.Value<string>()));
-                var sequencePoints = token["sequence-points"].Select(t => ParseSequencePoint(t.Value<string>()));
+                var sequencePoints = token["sequence-points"]
+                    .Select(t => ParseSequencePoint(t.Value<string>()))
+                    .OrderBy(sp => sp.Address);
                 var range = token.Value<string>("range").Split('-');
                 Debug.Assert(range.Length == 2);
 

--- a/src/adapter3/VariableContainers/ExecutionContextContainer.cs
+++ b/src/adapter3/VariableContainers/ExecutionContextContainer.cs
@@ -35,8 +35,8 @@ namespace NeoDebug.Neo3
                 {
                     var (name, type) = variableInfo[i];
                     if (name.Contains(':')) continue;
-                    var v = i < slot.Count 
-                        ? slot[i].ToVariable(manager, name, type) 
+                    var v = i < slot.Count
+                        ? slot[i].ToVariable(manager, name, type)
                         : StackItem.Null.ToVariable(manager, name, type);
 
                     yield return v.ForEvaluation();

--- a/src/adapter3/VariableContainers/StorageContainer.cs
+++ b/src/adapter3/VariableContainers/StorageContainer.cs
@@ -68,20 +68,20 @@ namespace NeoDebug.Neo3
         {
             bool TryGetKeyHash(out int value)
             {
-                if (expression.Length >= 18    
+                if (expression.Length >= 18
                     && expression.StartsWith("#storage[")
                     && expression.Span[17] == ']'
                     && expression.Span[18] == '.'
                     && int.TryParse(expression.Slice(9, 8).Span, NumberStyles.HexNumber, null, out value))
                 {
-                    return true;   
+                    return true;
                 }
 
                 value = default;
                 return false;
             }
 
-            if (TryGetKeyHash(out var keyHash) 
+            if (TryGetKeyHash(out var keyHash)
                 && TryFind(keyHash, out var tuple))
             {
                 var remain = expression.Slice(19);

--- a/src/adapter3/WitnessChecker.cs
+++ b/src/adapter3/WitnessChecker.cs
@@ -29,7 +29,7 @@ namespace NeoDebug.Neo3
 
         public static WitnessChecker Default => _default.Value;
 
-        public bool Check(Neo.UInt160 hash) 
+        public bool Check(Neo.UInt160 hash)
             => bypassCheck ? checkResult : witnesses.Contains(hash);
     }
 }

--- a/src/adapter3/neodebug-3-adapter.csproj
+++ b/src/adapter3/neodebug-3-adapter.csproj
@@ -24,10 +24,6 @@
     <PackageReference Include="Nito.Disposables" Version="2.1.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
     <PackageReference Include="Neo.Seattle.Persistence" Version="0.1.22-preview" />
+    <PackageReference Include="Neo" Version="3.0.0-preview3-00"/>
   </ItemGroup>
-  
-  <ItemGroup>
-    <ProjectReference Include="..\..\..\..\official\neo3\core\src\neo\neo.csproj" />
-  </ItemGroup>
-
 </Project>

--- a/src/adapter3/neodebug-3-adapter.csproj
+++ b/src/adapter3/neodebug-3-adapter.csproj
@@ -23,8 +23,11 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Nito.Disposables" Version="2.1.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
-    <PackageReference Include="Neo.Seattle.Persistence" Version="0.1.22-preview"/>
-    <PackageReference Include="Neo" Version="3.0.0-preview3-00"/>
+    <PackageReference Include="Neo.Seattle.Persistence" Version="0.1.22-preview" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\official\neo3\core\src\neo\neo.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/extension/package-lock.json
+++ b/src/extension/package-lock.json
@@ -5,29 +5,35 @@
 	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-			"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+			"integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
 			"dev": true,
 			"requires": {
-				"@babel/highlight": "^7.8.3"
+				"@babel/highlight": "^7.10.4"
 			}
 		},
+		"@babel/helper-validator-identifier": {
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+			"integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+			"dev": true
+		},
 		"@babel/highlight": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.8.3.tgz",
-			"integrity": "sha512-PX4y5xQUvy0fnEVHrYOarRPXVWafSjTW9T0Hab8gVIawpl2Sj0ORyrygANq+KjcNlSSTw0YCLSNA8OyZ1I4yEg==",
+			"version": "7.10.4",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+			"integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
 			"dev": true,
 			"requires": {
+				"@babel/helper-validator-identifier": "^7.10.4",
 				"chalk": "^2.0.0",
-				"esutils": "^2.0.2",
 				"js-tokens": "^4.0.0"
 			}
 		},
 		"@types/glob": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.2.tgz",
-			"integrity": "sha512-VgNIkxK+j7Nz5P7jvUZlRvhuPSmsEfS03b0alKcq5V/STUKAa3Plemsn5mrQUO7am6OErJ4rhGEGJbACclrtRA==",
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
+			"integrity": "sha512-SEYeGAIQIQX8NN6LDKprLjbrd5dARM5EXsd8GI/A5l0apYI1fGMWgPHSe4ZKL4eozlAyI+doUE9XbYS4xCkQ1w==",
 			"dev": true,
 			"requires": {
 				"@types/minimatch": "*",
@@ -41,9 +47,9 @@
 			"dev": true
 		},
 		"@types/mocha": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-7.0.2.tgz",
-			"integrity": "sha512-ZvO2tAcjmMi8V/5Z3JsyofMe3hasRcaw88cto5etSVMwVQfeivGAlEYmaQgceUSVYFofVjT+ioHsATjdWcFt1w==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.0.1.tgz",
+			"integrity": "sha512-TBZ6YdX7IZz4U9/mBoB8zCMRN1vXw8QdihRcZxD3I0Cv/r8XF8RggZ8WiXFws4aj5atzRR5hJrYer7g8nXwpnQ==",
 			"dev": true
 		},
 		"@types/node": {
@@ -53,9 +59,9 @@
 			"dev": true
 		},
 		"@types/vscode": {
-			"version": "1.42.0",
-			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.42.0.tgz",
-			"integrity": "sha512-ds6TceMsh77Fs0Mq0Vap6Y72JbGWB8Bay4DrnJlf5d9ui2RSe1wis13oQm+XhguOeH1HUfLGzaDAoupTUtgabw==",
+			"version": "1.47.0",
+			"resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.47.0.tgz",
+			"integrity": "sha512-nJA37ykkz9FYA0ZOQUSc3OZnhuzEW2vUhUEo4MiduUo82jGwwcLfyvmgd/Q7b0WrZAAceojGhZybg319L24bTA==",
 			"dev": true
 		},
 		"agent-base": {
@@ -247,6 +253,18 @@
 			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
 			"integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
 			"dev": true
+		},
+		"array.prototype.map": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/array.prototype.map/-/array.prototype.map-1.0.2.tgz",
+			"integrity": "sha512-Az3OYxgsa1g7xDYp86l0nnN4bcmuEITGe1rbdEBVkrqkzMgDcbdQ2R7r41pNzti+4NMces3H8gMmuioZUilLgw==",
+			"dev": true,
+			"requires": {
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0-next.1",
+				"es-array-method-boxes-properly": "^1.0.0",
+				"is-string": "^1.0.4"
+			}
 		},
 		"assign-symbols": {
 			"version": "1.0.0",
@@ -859,9 +877,9 @@
 			"dev": true
 		},
 		"diff": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+			"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
 			"dev": true
 		},
 		"dom-serializer": {
@@ -952,22 +970,51 @@
 			}
 		},
 		"es-abstract": {
-			"version": "1.17.5",
-			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-			"integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+			"version": "1.17.6",
+			"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+			"integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
 			"dev": true,
 			"requires": {
 				"es-to-primitive": "^1.2.1",
 				"function-bind": "^1.1.1",
 				"has": "^1.0.3",
 				"has-symbols": "^1.0.1",
-				"is-callable": "^1.1.5",
-				"is-regex": "^1.0.5",
+				"is-callable": "^1.2.0",
+				"is-regex": "^1.1.0",
 				"object-inspect": "^1.7.0",
 				"object-keys": "^1.1.1",
 				"object.assign": "^4.1.0",
-				"string.prototype.trimleft": "^2.1.1",
-				"string.prototype.trimright": "^2.1.1"
+				"string.prototype.trimend": "^1.0.1",
+				"string.prototype.trimstart": "^1.0.1"
+			}
+		},
+		"es-array-method-boxes-properly": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/es-array-method-boxes-properly/-/es-array-method-boxes-properly-1.0.0.tgz",
+			"integrity": "sha512-wd6JXUmyHmt8T5a2xreUwKcGPq6f1f+WwIJkijUqiGcJz1qqnZgP6XIK+QyIWU5lT7imeNxUll48bziG+TSYcA==",
+			"dev": true
+		},
+		"es-get-iterator": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/es-get-iterator/-/es-get-iterator-1.1.0.tgz",
+			"integrity": "sha512-UfrmHuWQlNMTs35e1ypnvikg6jCz3SK8v8ImvmDsh36fCVUR1MqoFDiyn0/k52C8NqO3YsO8Oe0azeesNuqSsQ==",
+			"dev": true,
+			"requires": {
+				"es-abstract": "^1.17.4",
+				"has-symbols": "^1.0.1",
+				"is-arguments": "^1.0.4",
+				"is-map": "^2.0.1",
+				"is-set": "^2.0.1",
+				"is-string": "^1.0.5",
+				"isarray": "^2.0.5"
+			},
+			"dependencies": {
+				"isarray": {
+					"version": "2.0.5",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+					"integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+					"dev": true
+				}
 			}
 		},
 		"es-to-primitive": {
@@ -1050,12 +1097,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
 			"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-			"dev": true
-		},
-		"esutils": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true
 		},
 		"expand-brackets": {
@@ -2315,6 +2356,12 @@
 				}
 			}
 		},
+		"is-arguments": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.0.4.tgz",
+			"integrity": "sha512-xPh0Rmt8NE65sNzvyUmWgI1tz3mKq74lGA0mL8LYZcoIzKOzDh6HmrYm3d18k60nHerC8A9Km8kYu87zfSFnLA==",
+			"dev": true
+		},
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
@@ -2337,9 +2384,9 @@
 			"dev": true
 		},
 		"is-callable": {
-			"version": "1.1.5",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-			"integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+			"integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
 			"dev": true
 		},
 		"is-data-descriptor": {
@@ -2423,6 +2470,12 @@
 				"is-extglob": "^2.1.1"
 			}
 		},
+		"is-map": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-map/-/is-map-2.0.1.tgz",
+			"integrity": "sha512-T/S49scO8plUiAOA2DBTBG3JHpn1yiw0kRp6dgiZ0v2/6twi5eiB0rHtHFH9ZIrvlWc6+4O+m4zg5+Z833aXgw==",
+			"dev": true
+		},
 		"is-negated-glob": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-negated-glob/-/is-negated-glob-1.0.0.tgz",
@@ -2455,6 +2508,12 @@
 				}
 			}
 		},
+		"is-plain-obj": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+			"integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+			"dev": true
+		},
 		"is-plain-object": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
@@ -2465,12 +2524,12 @@
 			}
 		},
 		"is-regex": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-			"integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+			"integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
 			"dev": true,
 			"requires": {
-				"has": "^1.0.3"
+				"has-symbols": "^1.0.1"
 			}
 		},
 		"is-relative": {
@@ -2481,6 +2540,18 @@
 			"requires": {
 				"is-unc-path": "^1.0.0"
 			}
+		},
+		"is-set": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-set/-/is-set-2.0.1.tgz",
+			"integrity": "sha512-eJEzOtVyenDs1TMzSQ3kU3K+E0GUS9sno+F0OBT97xsgcJsF9nXMBtkT9/kut5JEpM7oL7X/0qxR17K3mcwIAA==",
+			"dev": true
+		},
+		"is-string": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/is-string/-/is-string-1.0.5.tgz",
+			"integrity": "sha512-buY6VNRjhQMiF1qWDouloZlQbRhDPCebwxSjxMjxgemYT46YMd2NR0/H+fBhEfWX4A/w9TBJ+ol+okqJKFE6vQ==",
+			"dev": true
 		},
 		"is-symbol": {
 			"version": "1.0.3",
@@ -2535,6 +2606,22 @@
 			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
 			"integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
 			"dev": true
+		},
+		"iterate-iterator": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/iterate-iterator/-/iterate-iterator-1.0.1.tgz",
+			"integrity": "sha512-3Q6tudGN05kbkDQDI4CqjaBf4qf85w6W6GnuZDtUVYwKgtC1q8yxYX7CZed7N+tLzQqS6roujWvszf13T+n9aw==",
+			"dev": true
+		},
+		"iterate-value": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/iterate-value/-/iterate-value-1.0.2.tgz",
+			"integrity": "sha512-A6fMAio4D2ot2r/TYzr4yUWrmwNdsN5xL7+HUiyACE4DXm+q8HtPcnFTp+NnW3k4N05tZ7FVYFFb2CR13NxyHQ==",
+			"dev": true,
+			"requires": {
+				"es-get-iterator": "^1.0.2",
+				"iterate-iterator": "^1.0.1"
+			}
 		},
 		"js-tokens": {
 			"version": "4.0.0",
@@ -2652,21 +2739,12 @@
 			}
 		},
 		"locate-path": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-			"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
 			"dev": true,
 			"requires": {
-				"p-locate": "^3.0.0",
-				"path-exists": "^3.0.0"
-			},
-			"dependencies": {
-				"path-exists": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
-					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
-					"dev": true
-				}
+				"p-locate": "^4.1.0"
 			}
 		},
 		"lodash": {
@@ -2815,9 +2893,9 @@
 			}
 		},
 		"minimist": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-			"integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 			"dev": true
 		},
 		"mixin-deep": {
@@ -2842,50 +2920,51 @@
 			}
 		},
 		"mkdirp": {
-			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-			"integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+			"version": "0.5.5",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
 			"dev": true,
 			"requires": {
-				"minimist": "0.0.8"
+				"minimist": "^1.2.5"
 			}
 		},
 		"mocha": {
-			"version": "7.1.2",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.2.tgz",
-			"integrity": "sha512-o96kdRKMKI3E8U0bjnfqW4QMk12MwZ4mhdBTf+B5a1q9+aq2HRnj+3ZdJu0B/ZhJeK78MgYuv6L8d/rA5AeBJA==",
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-8.1.0.tgz",
+			"integrity": "sha512-sI0gaI1I/jPVu3KFpnveWGadfe3JNBAENqgTUPgLZAUppu725zS2mrVztzAgIR8DUscuS4doEBTx9LATC+HSeA==",
 			"dev": true,
 			"requires": {
-				"ansi-colors": "3.2.3",
+				"ansi-colors": "4.1.1",
 				"browser-stdout": "1.3.1",
-				"chokidar": "3.3.0",
+				"chokidar": "3.3.1",
 				"debug": "3.2.6",
-				"diff": "3.5.0",
+				"diff": "4.0.2",
 				"escape-string-regexp": "1.0.5",
-				"find-up": "3.0.0",
-				"glob": "7.1.3",
+				"find-up": "4.1.0",
+				"glob": "7.1.6",
 				"growl": "1.10.5",
 				"he": "1.2.0",
 				"js-yaml": "3.13.1",
 				"log-symbols": "3.0.0",
 				"minimatch": "3.0.4",
-				"mkdirp": "0.5.5",
-				"ms": "2.1.1",
-				"node-environment-flags": "1.0.6",
+				"ms": "2.1.2",
 				"object.assign": "4.1.0",
-				"strip-json-comments": "2.0.1",
-				"supports-color": "6.0.0",
-				"which": "1.3.1",
+				"promise.allsettled": "1.0.2",
+				"serialize-javascript": "4.0.0",
+				"strip-json-comments": "3.0.1",
+				"supports-color": "7.1.0",
+				"which": "2.0.2",
 				"wide-align": "1.1.3",
+				"workerpool": "6.0.0",
 				"yargs": "13.3.2",
 				"yargs-parser": "13.1.2",
-				"yargs-unparser": "1.6.0"
+				"yargs-unparser": "1.6.1"
 			},
 			"dependencies": {
 				"ansi-colors": {
-					"version": "3.2.3",
-					"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
-					"integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw==",
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.1.tgz",
+					"integrity": "sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==",
 					"dev": true
 				},
 				"ansi-regex": {
@@ -2905,9 +2984,9 @@
 					}
 				},
 				"binary-extensions": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-					"integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+					"integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
 					"dev": true
 				},
 				"braces": {
@@ -2926,19 +3005,19 @@
 					"dev": true
 				},
 				"chokidar": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.0.tgz",
-					"integrity": "sha512-dGmKLDdT3Gdl7fBUe8XK+gAtGmzy5Fn0XkkWQuYxGIgWVPPse2CxFA5mtrlD0TOHaHjEUqkWNyP1XdHoJES/4A==",
+					"version": "3.3.1",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
+					"integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
 					"dev": true,
 					"requires": {
 						"anymatch": "~3.1.1",
 						"braces": "~3.0.2",
-						"fsevents": "~2.1.1",
+						"fsevents": "~2.1.2",
 						"glob-parent": "~5.1.0",
 						"is-binary-path": "~2.1.0",
 						"is-glob": "~4.0.1",
 						"normalize-path": "~3.0.0",
-						"readdirp": "~3.2.0"
+						"readdirp": "~3.3.0"
 					}
 				},
 				"cliui": {
@@ -2962,12 +3041,13 @@
 					}
 				},
 				"find-up": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-					"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
 					"dev": true,
 					"requires": {
-						"locate-path": "^3.0.0"
+						"locate-path": "^5.0.0",
+						"path-exists": "^4.0.0"
 					}
 				},
 				"fsevents": {
@@ -2982,20 +3062,6 @@
 					"resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
 					"integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
 					"dev": true
-				},
-				"glob": {
-					"version": "7.1.3",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-					"integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-					"dev": true,
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.0.4",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
 				},
 				"glob-parent": {
 					"version": "5.1.1",
@@ -3027,34 +3093,34 @@
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 					"dev": true
 				},
-				"minimist": {
-					"version": "1.2.5",
-					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-					"dev": true
-				},
-				"mkdirp": {
-					"version": "0.5.5",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-					"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.5"
-					}
-				},
 				"normalize-path": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
 					"dev": true
 				},
-				"readdirp": {
-					"version": "3.2.0",
-					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.2.0.tgz",
-					"integrity": "sha512-crk4Qu3pmXwgxdSgGhgA/eXiJAPQiX4GMOZZMXnqKxHX7TaoL+3gQVo/WeuAiogr07DpnfjIMpXXa+PAIvwPGQ==",
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
 					"dev": true,
 					"requires": {
-						"picomatch": "^2.0.4"
+						"p-limit": "^2.0.0"
+					}
+				},
+				"path-exists": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+					"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+					"dev": true
+				},
+				"readdirp": {
+					"version": "3.3.0",
+					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
+					"integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
+					"dev": true,
+					"requires": {
+						"picomatch": "^2.0.7"
 					}
 				},
 				"require-main-filename": {
@@ -3090,6 +3156,15 @@
 					"dev": true,
 					"requires": {
 						"is-number": "^7.0.0"
+					}
+				},
+				"which": {
+					"version": "2.0.2",
+					"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+					"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+					"dev": true,
+					"requires": {
+						"isexe": "^2.0.0"
 					}
 				},
 				"which-module": {
@@ -3131,6 +3206,33 @@
 						"which-module": "^2.0.0",
 						"y18n": "^4.0.0",
 						"yargs-parser": "^13.1.2"
+					},
+					"dependencies": {
+						"find-up": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+							"integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+							"dev": true,
+							"requires": {
+								"locate-path": "^3.0.0"
+							}
+						},
+						"locate-path": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+							"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+							"dev": true,
+							"requires": {
+								"p-locate": "^3.0.0",
+								"path-exists": "^3.0.0"
+							}
+						},
+						"path-exists": {
+							"version": "3.0.0",
+							"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+							"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+							"dev": true
+						}
 					}
 				},
 				"yargs-parser": {
@@ -3146,9 +3248,9 @@
 			}
 		},
 		"ms": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
 		},
 		"mute-stdout": {
@@ -3190,9 +3292,9 @@
 			}
 		},
 		"nerdbank-gitversioning": {
-			"version": "3.1.91",
-			"resolved": "https://registry.npmjs.org/nerdbank-gitversioning/-/nerdbank-gitversioning-3.1.91.tgz",
-			"integrity": "sha512-HxP0gGCVM7SN0LY8W1lEFq6RjkssgWOfnKVB2ozZWaGOjrG52qyNoiq+/NuP2ym544OG0UOk3XXxIR6oxbpedQ==",
+			"version": "3.2.31",
+			"resolved": "https://registry.npmjs.org/nerdbank-gitversioning/-/nerdbank-gitversioning-3.2.31.tgz",
+			"integrity": "sha512-tu9vxuy2UOIrBhivGB+FDAQ46IT9imIRNPwzkpx3z4i1Nhc9IsnYSSFOJ4VNzmfh49n0ir6ZyS+ZJYQCTXVIMA==",
 			"dev": true,
 			"requires": {
 				"camel-case": "^4.1.1"
@@ -3212,16 +3314,6 @@
 			"requires": {
 				"lower-case": "^2.0.1",
 				"tslib": "^1.10.0"
-			}
-		},
-		"node-environment-flags": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
-			"integrity": "sha512-5Evy2epuL+6TM0lCQGpFIj6KwiEsGh1SrHUhTbNX+sLbBtjidPZFAnVK9y5yU1+h//RitLbRHTIMyxQPtxMdHw==",
-			"dev": true,
-			"requires": {
-				"object.getownpropertydescriptors": "^2.0.3",
-				"semver": "^5.7.0"
 			}
 		},
 		"normalize-package-data": {
@@ -3307,9 +3399,9 @@
 			}
 		},
 		"object-inspect": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-			"integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+			"integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
 			"dev": true
 		},
 		"object-keys": {
@@ -3349,16 +3441,6 @@
 				"array-slice": "^1.0.0",
 				"for-own": "^1.0.0",
 				"isobject": "^3.0.0"
-			}
-		},
-		"object.getownpropertydescriptors": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
-			"integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.0-next.1"
 			}
 		},
 		"object.map": {
@@ -3454,12 +3536,12 @@
 			}
 		},
 		"p-locate": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-			"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
 			"dev": true,
 			"requires": {
-				"p-limit": "^2.0.0"
+				"p-limit": "^2.2.0"
 			}
 		},
 		"p-try": {
@@ -3637,6 +3719,19 @@
 			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
 			"dev": true
 		},
+		"promise.allsettled": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/promise.allsettled/-/promise.allsettled-1.0.2.tgz",
+			"integrity": "sha512-UpcYW5S1RaNKT6pd+s9jp9K9rlQge1UXKskec0j6Mmuq7UJCvlS2J2/s/yuPN8ehftf9HXMxWlKiPbGGUzpoRg==",
+			"dev": true,
+			"requires": {
+				"array.prototype.map": "^1.0.1",
+				"define-properties": "^1.1.3",
+				"es-abstract": "^1.17.0-next.1",
+				"function-bind": "^1.1.1",
+				"iterate-value": "^1.0.0"
+			}
+		},
 		"pump": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
@@ -3656,6 +3751,15 @@
 				"duplexify": "^3.6.0",
 				"inherits": "^2.0.3",
 				"pump": "^2.0.0"
+			}
+		},
+		"randombytes": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
+			"integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "^5.1.0"
 			}
 		},
 		"read": {
@@ -3904,6 +4008,15 @@
 			"dev": true,
 			"requires": {
 				"sver-compat": "^1.5.0"
+			}
+		},
+		"serialize-javascript": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-4.0.0.tgz",
+			"integrity": "sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==",
+			"dev": true,
+			"requires": {
+				"randombytes": "^2.1.0"
 			}
 		},
 		"set-blocking": {
@@ -4201,28 +4314,6 @@
 				"es-abstract": "^1.17.5"
 			}
 		},
-		"string.prototype.trimleft": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
-			"integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.5",
-				"string.prototype.trimstart": "^1.0.0"
-			}
-		},
-		"string.prototype.trimright": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
-			"integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
-			"dev": true,
-			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.17.5",
-				"string.prototype.trimend": "^1.0.0"
-			}
-		},
 		"string.prototype.trimstart": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
@@ -4261,18 +4352,26 @@
 			}
 		},
 		"strip-json-comments": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"version": "3.0.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.0.1.tgz",
+			"integrity": "sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==",
 			"dev": true
 		},
 		"supports-color": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.0.0.tgz",
-			"integrity": "sha512-on9Kwidc1IUQo+bQdhi8+Tijpo0e1SS6RoGo2guUwn5vdaxw8RXOF9Vb2ws+ihWOmh4JnCJOvaziZWP1VABaLg==",
+			"version": "7.1.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+			"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
 			"dev": true,
 			"requires": {
-				"has-flag": "^3.0.0"
+				"has-flag": "^4.0.0"
+			},
+			"dependencies": {
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+					"dev": true
+				}
 			}
 		},
 		"sver-compat": {
@@ -4388,15 +4487,15 @@
 			}
 		},
 		"tslib": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-			"integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
+			"version": "1.13.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
+			"integrity": "sha512-i/6DQjL8Xf3be4K/E6Wgpekn5Qasl1usyw++dAA35Ue5orEn65VIxOA+YvNNl9HV3qv70T7CNwjODHZrLwvd1Q==",
 			"dev": true
 		},
 		"tslint": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/tslint/-/tslint-6.0.0.tgz",
-			"integrity": "sha512-9nLya8GBtlFmmFMW7oXXwoXS1NkrccqTqAtwXzdPV9e2mqSEvCki6iHL/Fbzi5oqbugshzgGPk7KBb2qNP1DSA==",
+			"version": "6.1.3",
+			"resolved": "https://registry.npmjs.org/tslint/-/tslint-6.1.3.tgz",
+			"integrity": "sha512-IbR4nkT96EQOvKE2PW/djGz8iGNeJ4rF2mBfiYaR/nvUWYKJhLwimoJKgjIFEIDibBtOevj7BqCRL4oHeWWUCg==",
 			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.0.0",
@@ -4407,19 +4506,11 @@
 				"glob": "^7.1.1",
 				"js-yaml": "^3.13.1",
 				"minimatch": "^3.0.4",
-				"mkdirp": "^0.5.1",
+				"mkdirp": "^0.5.3",
 				"resolve": "^1.3.2",
 				"semver": "^5.3.0",
-				"tslib": "^1.10.0",
+				"tslib": "^1.13.0",
 				"tsutils": "^2.29.0"
-			},
-			"dependencies": {
-				"diff": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-					"dev": true
-				}
 			}
 		},
 		"tsutils": {
@@ -4460,9 +4551,9 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+			"version": "3.9.7",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
+			"integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
 			"dev": true
 		},
 		"uc.micro": {
@@ -4706,9 +4797,9 @@
 			}
 		},
 		"vscode-test": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.3.0.tgz",
-			"integrity": "sha512-LddukcBiSU2FVTDr3c1D8lwkiOvwlJdDL2hqVbn6gIz+rpTqUCkMZSKYm94Y1v0WXlHSDQBsXyY+tchWQgGVsw==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.4.0.tgz",
+			"integrity": "sha512-Jt7HNGvSE0+++Tvtq5wc4hiXLIr2OjDShz/gbAfM/mahQpy4rKBnmOK33D+MR67ATWviQhl+vpmU3p/qwSH/Pg==",
 			"dev": true,
 			"requires": {
 				"http-proxy-agent": "^2.1.0",
@@ -4739,6 +4830,12 @@
 			"requires": {
 				"string-width": "^1.0.2 || 2"
 			}
+		},
+		"workerpool": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.0.0.tgz",
+			"integrity": "sha512-fU2OcNA/GVAJLLyKUoHkAgIhKb0JoCpSjLC/G2vYKxUjVmQwGbRVeoPJ1a8U4pnVofz4AQV5Y/NEw8oKqxEBtA==",
+			"dev": true
 		},
 		"wrap-ansi": {
 			"version": "2.1.0",
@@ -4798,14 +4895,16 @@
 			}
 		},
 		"yargs-unparser": {
-			"version": "1.6.0",
-			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
-			"integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.1.tgz",
+			"integrity": "sha512-qZV14lK9MWsGCmcr7u5oXGH0dbGqZAIxTDrWXZDo5zUr6b6iUmelNKO6x6R1dQT24AH3LgRxJpr8meWy2unolA==",
 			"dev": true,
 			"requires": {
+				"camelcase": "^5.3.1",
+				"decamelize": "^1.2.0",
 				"flat": "^4.1.0",
-				"lodash": "^4.17.15",
-				"yargs": "^13.3.0"
+				"is-plain-obj": "^1.1.0",
+				"yargs": "^14.2.3"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -4850,6 +4949,31 @@
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
 					"integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+					"dev": true
+				},
+				"locate-path": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+					"integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+					"dev": true,
+					"requires": {
+						"p-locate": "^3.0.0",
+						"path-exists": "^3.0.0"
+					}
+				},
+				"p-locate": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+					"integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+					"dev": true,
+					"requires": {
+						"p-limit": "^2.0.0"
+					}
+				},
+				"path-exists": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+					"integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
 					"dev": true
 				},
 				"require-main-filename": {
@@ -4902,12 +5026,13 @@
 					"dev": true
 				},
 				"yargs": {
-					"version": "13.3.2",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.2.tgz",
-					"integrity": "sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==",
+					"version": "14.2.3",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-14.2.3.tgz",
+					"integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
 					"dev": true,
 					"requires": {
 						"cliui": "^5.0.0",
+						"decamelize": "^1.2.0",
 						"find-up": "^3.0.0",
 						"get-caller-file": "^2.0.1",
 						"require-directory": "^2.1.1",
@@ -4916,13 +5041,13 @@
 						"string-width": "^3.0.0",
 						"which-module": "^2.0.0",
 						"y18n": "^4.0.0",
-						"yargs-parser": "^13.1.2"
+						"yargs-parser": "^15.0.1"
 					}
 				},
 				"yargs-parser": {
-					"version": "13.1.2",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.2.tgz",
-					"integrity": "sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==",
+					"version": "15.0.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-15.0.1.tgz",
+					"integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
 					"dev": true,
 					"requires": {
 						"camelcase": "^5.0.0",

--- a/src/extension/package.json
+++ b/src/extension/package.json
@@ -349,16 +349,16 @@
         "glob": "^7.1.6"
     },
     "devDependencies": {
-        "@types/glob": "^7.1.2",
-        "@types/mocha": "^7.0.2",
+        "@types/glob": "^7.1.3",
+        "@types/mocha": "^8.0.1",
         "@types/node": "^12.8.1",
-        "@types/vscode": "^1.42.0",
+        "@types/vscode": "^1.47.0",
         "gulp": "4.0.2",
-        "mocha": "^7.1.2",
-        "nerdbank-gitversioning": "^3.1.91",
-        "tslint": "^6.0.0",
-        "typescript": "^3.8.3",
+        "mocha": "^8.1.0",
+        "nerdbank-gitversioning": "^3.2.31",
+        "tslint": "^6.1.3",
+        "typescript": "^3.9.7",
         "vsce": "^1.77.0",
-        "vscode-test": "^1.3.0"
+        "vscode-test": "^1.4.0"
     }
 }

--- a/src/extension/package.json
+++ b/src/extension/package.json
@@ -352,7 +352,7 @@
         "@types/glob": "^7.1.3",
         "@types/mocha": "^8.0.1",
         "@types/node": "^12.8.1",
-        "@types/vscode": "^1.47.0",
+        "@types/vscode": "^1.42.0",
         "gulp": "4.0.2",
         "mocha": "^8.1.0",
         "nerdbank-gitversioning": "^3.2.31",

--- a/src/extension/src/test/suite/index.ts
+++ b/src/extension/src/test/suite/index.ts
@@ -7,7 +7,7 @@ export function run(): Promise<void> {
 	const mocha = new Mocha({
 		ui: 'tdd',
 	});
-	mocha.useColors(true);
+	// mocha.useColors(true);
 
 	const testsRoot = path.resolve(__dirname, '..');
 


### PR DESCRIPTION
This PR adds exception breakpoint support to the Neo 3 debug adapter (Neo 2 did not support try/catch). This incldues:

* ExceptionBreakpointFilters for caught + uncaught exceptions
* Add ExceptionInfo request support
* return unhandled exception info on fault when available
* Modifying DebugApplicationEngine.ExecuteInstruction to enable breaking between THROW and handling the exception
* DRYing out step/continue logic

fixes #69