### PR TITLE
Minor Cleannup

### DIFF
--- a/src/adapter2/LaunchConfigurationParser.cs
+++ b/src/adapter2/LaunchConfigurationParser.cs
@@ -16,7 +16,7 @@ using Newtonsoft.Json.Linq;
 
 namespace NeoDebug
 {
-    class LaunchConfigurationParser
+    static class LaunchConfigurationParser
     {
         public static async Task<DebugSession> CreateDebugSession(LaunchArguments arguments, Action<DebugEvent> sendEvent, DebugSession.DebugView defaultDebugView)
         {

--- a/src/adapter3/DebugSession.cs
+++ b/src/adapter3/DebugSession.cs
@@ -137,14 +137,13 @@ namespace NeoDebug.Neo3
                 if (disassemblyView)
                 {
                     var disassembly = disassemblyManager.GetDisassembly(context.Script, debugInfo);
-                    var line = disassembly.AddressMap[context.InstructionPointer];
                     frame.Source = new Source()
                     {
                         SourceReference = disassembly.SourceReference,
                         Name = disassembly.Name,
                         Path = disassembly.Name,
                     };
-                    frame.Line = line; //index == 0 ? line : line - 1;   
+                    frame.Line = disassembly.AddressMap[context.InstructionPointer];
                     frame.Column = 1;
                 }
                 else

--- a/src/adapter3/DisassemblyManager.cs
+++ b/src/adapter3/DisassemblyManager.cs
@@ -145,17 +145,17 @@ namespace NeoDebug.Neo3
 
         static IEnumerable<(int address, Instruction instruction)> EnumerateInstructions(Script script)
         {
-            int address = 0;
-            bool lastInstructionRet = false;
+            var address = 0;
+            var opcode = OpCode.PUSH0;
             while (address < script.Length)
             {
                 var instruction = script.GetInstruction(address);
-                lastInstructionRet = instruction.OpCode == OpCode.RET;
+                opcode = instruction.OpCode;
                 yield return (address, instruction);
-                address = address + instruction.Size;
+                address += instruction.Size;
             }
 
-            if (!lastInstructionRet)
+            if (opcode != OpCode.RET)
             {
                 yield return (address, Instruction.RET);
             }


### PR DESCRIPTION
* Fire instance DebugNotify/Log events based on static Notify/Log events instead of overriding System.Runtime.Notify/Log
* Use CreateSearchPrefix in StorageContainer