### PR TITLE
TryGetNativeContract during trace debugging

### DIFF
--- a/src/adapter3/TraceApplicationEngine.ExecutionContextAdapter.cs
+++ b/src/adapter3/TraceApplicationEngine.ExecutionContextAdapter.cs
@@ -4,7 +4,7 @@ using StackItem = Neo.VM.Types.StackItem;
 using Neo;
 using Neo.VM;
 using Neo.BlockchainToolkit.TraceDebug;
-using System.Linq;
+using Neo.SmartContract.Native;
 
 namespace NeoDebug.Neo3
 {
@@ -32,7 +32,7 @@ namespace NeoDebug.Neo3
 
                 static bool TryGetNativeContract(UInt160 scriptHash, out Script script)
                 {
-                    foreach (var nativeContract in Neo.SmartContract.Native.NativeContract.Contracts)
+                    foreach (var nativeContract in NativeContract.Contracts)
                     {
                         if (scriptHash == nativeContract.Hash)
                         {


### PR DESCRIPTION
Trace debugging capture the invocation script in the trace file and users are expected to have .nef/.nefdbgnfo files for all scripts invoked. However, the user won't have .nef/.nefdbgnfo files for native contracts (such as NEO or GAS NEP-5 token contracts). 

If the trace file references a native contract, this PR adds the capability to load the script binary (no .nefdbgnfo support) from the native contracts stored in the NEO binary via NativeContract.Contracts collection