### PR TITLE
Add invoke-file and signers support to neo 3 launch configuration

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,6 @@
 {
     "cSpell.words": [
-        "Nito"
+        "Nito",
+        "neovm"
     ]
 }

--- a/src/adapter3/ContractParameterParser.cs
+++ b/src/adapter3/ContractParameterParser.cs
@@ -1,12 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.IO;
 using System.Linq;
 using System.Numerics;
+using System.Text;
+using System.Threading.Tasks;
 using Neo;
 using Neo.Cryptography.ECC;
+using Neo.IO;
 using Neo.SmartContract;
+using Neo.VM;
 using Neo.Wallets;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace NeoDebug.Neo3
@@ -14,6 +20,74 @@ namespace NeoDebug.Neo3
     // https://gist.github.com/devhawk/4394bb9be2af0b0ff54211b41574b65b
     public static class ContractParameterParser
     {
+        public static async Task<Script> LoadInvocationScript(string invocationFilePath)
+        {
+            JToken invokeFileJson;
+            {
+                using var fileStream = File.OpenRead(invocationFilePath);
+                using var textReader = new StreamReader(fileStream);
+                using var jsonReader = new JsonTextReader(textReader);
+                invokeFileJson = await JToken.LoadAsync(jsonReader).ConfigureAwait(false);
+            }
+
+            using var sb = new ScriptBuilder();
+            switch (invokeFileJson.Type)
+            {
+                case JTokenType.Object:
+                    EmitAppCall(sb, (JObject)invokeFileJson);
+                    break;
+                case JTokenType.Array:
+                    {
+                        JArray array = (JArray)invokeFileJson;
+                        for (int i = 0; i < array.Count; i++)
+                        {
+                            if (array[i].Type != JTokenType.Object) 
+                            {
+                                throw new InvalidDataException("invalid invocation file");
+                            }
+                            EmitAppCall(sb, (JObject)array[i]);
+                        }
+                    }
+                    break;
+                default:
+                    throw new InvalidDataException("invalid invocation file");
+            }
+            return sb.ToArray();
+
+            void EmitAppCall(ScriptBuilder scriptBuilder, JObject json)
+            {
+                var scriptHash = GetScriptHash(json["contract"]);
+                var operation = json.Value<string>("operation");
+                var args = ContractParameterParser.ParseParams(json.GetValue("args")).ToArray();
+                scriptBuilder.EmitAppCall(scriptHash, operation, args);
+            }
+
+            UInt160 GetScriptHash(JToken? json)
+            {
+                if (json != null && json is JObject jObject)
+                {
+                    if (jObject.TryGetValue("hash", out var jsonHash))
+                    {
+                        return UInt160.Parse(jsonHash.Value<string>());
+                    }
+
+                    if (jObject.TryGetValue("path", out var jsonPath))
+                    {
+                        var path = jsonPath.Value<string>();
+                        path = Path.IsPathFullyQualified(path)
+                            ? path
+                            : Path.Combine(Path.GetDirectoryName(invocationFilePath)!, path);
+
+                        using var stream = File.OpenRead(path);
+                        using var reader = new BinaryReader(stream, Encoding.UTF8, false);
+                        return reader.ReadSerializable<NefFile>().ScriptHash;
+                    }
+                }
+
+                throw new InvalidDataException("invalid contract property");
+            }
+        }
+
         public static IEnumerable<ContractParameter> ParseParams(JToken? @params)
         {
             if (@params == null)
@@ -56,17 +130,37 @@ namespace NeoDebug.Neo3
 
         public static ContractParameter ParseStringParam(string param)
         {
-            if (param.StartsWith("@N"))
+            if (TryParseScriptHash(out var scriptHash))
             {
                 return new ContractParameter()
                 {
                     Type = ContractParameterType.Hash160,
-                    Value = param.Substring(1).ToScriptHash()
+                    Value = scriptHash
+                };
+            }
+
+            if (param[0] == '#'
+                && UInt160.TryParse(param[1..], out var uint160))
+            {
+                return new ContractParameter()
+                {
+                    Type = ContractParameterType.Hash160,
+                    Value = uint160
+                };
+            }
+
+            if (param[0] == '#'
+                && UInt256.TryParse(param[1..], out var uint256))
+            {
+                return new ContractParameter()
+                {
+                    Type = ContractParameterType.Hash256,
+                    Value = uint256
                 };
             }
 
             if (param.StartsWith("0x")
-                && BigInteger.TryParse(param.AsSpan().Slice(2), NumberStyles.HexNumber, null, out var bigInteger))
+                && BigInteger.TryParse(param.AsSpan()[2..], NumberStyles.HexNumber, null, out var bigInteger))
             {
                 return new ContractParameter()
                 {
@@ -80,6 +174,24 @@ namespace NeoDebug.Neo3
                 Type = ContractParameterType.String,
                 Value = param
             };
+
+            bool TryParseScriptHash(out UInt160 value)
+            {
+                try
+                {
+                    if (param[0] == '@')
+                    {
+                        value = param[1..].ToScriptHash();
+                        return true;
+                    }
+                }
+                catch
+                {
+                }
+
+                value = default!;
+                return false;
+            }
         }
 
         private static ContractParameter ParseObjectParam(JObject param)
@@ -89,16 +201,16 @@ namespace NeoDebug.Neo3
 
             object value = type switch
             {
-                ContractParameterType.ByteArray => ParseByteArray(jValue),
-                ContractParameterType.Signature => ParseByteArray(jValue),
+                ContractParameterType.Array => jValue.Select(ParseParam).ToArray(),
                 ContractParameterType.Boolean => jValue.Value<bool>(),
-                ContractParameterType.Integer => BigInteger.Parse(jValue.Value<string>()),
+                ContractParameterType.ByteArray => ParseByteArray(jValue),
                 ContractParameterType.Hash160 => UInt160.Parse(jValue.Value<string>()),
                 ContractParameterType.Hash256 => UInt256.Parse(jValue.Value<string>()),
-                ContractParameterType.PublicKey => ECPoint.Parse(jValue.Value<string>(), ECCurve.Secp256r1),
-                ContractParameterType.String => jValue.Value<string>(),
-                ContractParameterType.Array => jValue.Select(ParseParam).ToArray(),
+                ContractParameterType.Integer => BigInteger.Parse(jValue.Value<string>()),
                 ContractParameterType.Map => jValue.Select(ParseMapElement).ToArray(),
+                ContractParameterType.PublicKey => ECPoint.Parse(jValue.Value<string>(), ECCurve.Secp256r1),
+                ContractParameterType.Signature => ParseByteArray(jValue),
+                ContractParameterType.String => jValue.Value<string>(),
                 _ => throw new ArgumentException(nameof(param) + $" {type}"),
             };
 
@@ -112,7 +224,7 @@ namespace NeoDebug.Neo3
             {
                 var value = json.Value<string>();
                 return value.StartsWith("0x")
-                    ? value.Substring(2).HexToBytes()
+                    ? value[2..].HexToBytes()
                     : Convert.FromBase64String(value);
             }
 

--- a/src/adapter3/LaunchConfigParser.cs
+++ b/src/adapter3/LaunchConfigParser.cs
@@ -74,7 +74,7 @@ namespace NeoDebug.Neo3
 
             var launchContract = LoadContract(config["program"].Value<string>());
             var invokeScript = await CreateLaunchScript(launchContract.ScriptHash, config);
-            var signer = Neo.Wallets.Helper.ToScriptHash("Nc2TJmEh7oM2wrXKdAQH5gHpy8HnyztcME");
+            // var signer = Neo.Wallets.Helper.ToScriptHash("Nc2TJmEh7oM2wrXKdAQH5gHpy8HnyztcME");
 
             var tx = new Transaction
             {

--- a/src/extension/package.json
+++ b/src/extension/package.json
@@ -150,6 +150,29 @@
                                 "type": "string",
                                 "description": "Absolute path to .neo-trace file"
                             },
+                            "signers": {
+                                "type": "array",
+                                "default": [],
+                                "required": [
+                                    "account"
+                                ],
+                                "properties": {
+                                    "account": {
+                                        "type": "string"
+                                    },
+                                    "scopes": {
+                                        "type": "string",
+                                        "default": "CalledByEntry",
+                                        "enum": [
+                                            "FeeOnly",
+                                            "CalledByEntry",
+                                            "CustomContracts",
+                                            "CustomGroups",
+                                            "Global"
+                                        ]
+                                    }
+                                }
+                            },
                             "utxo": {
                                 "type": "object",
                                 "description": "UTXO assets (aka NEO and GAS) to attach to the transaction being debugged",

--- a/src/extension/package.json
+++ b/src/extension/package.json
@@ -139,6 +139,9 @@
                                 "description": "Command line arguments passed to the program.",
                                 "default": []
                             },
+                            "invoke-file": {
+                                "type": "string"
+                            },
                             "checkpoint": {
                                 "type": "string",
                                 "description": "Optional neo-express checkpoint file used for contract execution"

--- a/src/extension/src/extension.ts
+++ b/src/extension/src/extension.ts
@@ -246,7 +246,6 @@ function validateNeo2DebugConfig(config: vscode.DebugConfiguration) {
     if (config["operation"]) {
         throw new Error("operation configuration not supported in Neo 2");
     }
-
 }
 
 function validateNeo3DebugConfig(config: vscode.DebugConfiguration) {
@@ -254,11 +253,6 @@ function validateNeo3DebugConfig(config: vscode.DebugConfiguration) {
     if (config["utxo"]) {
         throw new Error("utxo configuration not supported in Neo 3");
     }
-
-    if (!config["operation"] && !config["trace-file"]) {
-        throw new Error("operation configuration required in Neo 3 unless trace debugging");
-    }
-
 }
 
 function validateDebugConfig(program: string, config: vscode.DebugConfiguration) {


### PR DESCRIPTION
This PR adds two new launch config options. As of now, these are only parsed by the neo 3 debug adapter.

* `invoke-file` specifies a path to an [NDX-DN12 contract invoke file](https://github.com/ngdseattle/design-notes/blob/master/NDX-DN12%20-%20Neo%20Express%20Invoke%20Files.md). When specified, `operation` and `args` config parameters are ignored.
* `signers` specifies an array of Signers for the generated transaction executed by the application engine. Each signer JSON object has a the base58 encoded Neo 3 `address` property as well as an optional `scopes` property.  