### PR TITLE
Use extensionMode to detect Development Mode

### DIFF
--- a/src/extension/package-lock.json
+++ b/src/extension/package-lock.json
@@ -3369,9 +3369,9 @@
 			}
 		},
 		"nerdbank-gitversioning": {
-			"version": "3.2.31",
-			"resolved": "https://registry.npmjs.org/nerdbank-gitversioning/-/nerdbank-gitversioning-3.2.31.tgz",
-			"integrity": "sha512-tu9vxuy2UOIrBhivGB+FDAQ46IT9imIRNPwzkpx3z4i1Nhc9IsnYSSFOJ4VNzmfh49n0ir6ZyS+ZJYQCTXVIMA==",
+			"version": "3.3.37",
+			"resolved": "https://registry.npmjs.org/nerdbank-gitversioning/-/nerdbank-gitversioning-3.3.37.tgz",
+			"integrity": "sha512-zxLPVvglIvyF7/iYmYvRoOwhD+TpL7H/bV+lzkFgL7lBzfIVr4zYWr0Ly36E6n6oBs4oDT6tJKG7AE7GuJZcsA==",
 			"dev": true,
 			"requires": {
 				"camel-case": "^4.1.1"
@@ -4633,9 +4633,9 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "4.0.3",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
-			"integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.5.tgz",
+			"integrity": "sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==",
 			"dev": true
 		},
 		"uc.micro": {
@@ -4851,15 +4851,15 @@
 			}
 		},
 		"vsce": {
-			"version": "1.80.0",
-			"resolved": "https://registry.npmjs.org/vsce/-/vsce-1.80.0.tgz",
-			"integrity": "sha512-pnJT0LttCd5k1fJRsTOer8NvgesMYxLZYTUwuVWVOgONK9w+U5Yf32rtm4cX374TsHZbBwUr6ZFLP36wyDD8/g==",
+			"version": "1.81.1",
+			"resolved": "https://registry.npmjs.org/vsce/-/vsce-1.81.1.tgz",
+			"integrity": "sha512-1yWAYRxTx/PKSFZnuELe7GPyIo70H/XKJqf6wGikofUK3f3TCNGI6F9xkTQFvXKNe0AygUuxN7kITyPIQGMP+w==",
 			"dev": true,
 			"requires": {
 				"azure-devops-node-api": "^7.2.0",
 				"chalk": "^2.4.2",
 				"cheerio": "^1.0.0-rc.1",
-				"commander": "^2.8.1",
+				"commander": "^6.1.0",
 				"denodeify": "^1.2.1",
 				"glob": "^7.0.6",
 				"leven": "^3.1.0",
@@ -4876,6 +4876,14 @@
 				"url-join": "^1.1.0",
 				"yauzl": "^2.3.1",
 				"yazl": "^2.2.2"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "6.2.0",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-6.2.0.tgz",
+					"integrity": "sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==",
+					"dev": true
+				}
 			}
 		},
 		"vscode-test": {

--- a/src/extension/package-lock.json
+++ b/src/extension/package-lock.json
@@ -30,6 +30,12 @@
 				"js-tokens": "^4.0.0"
 			}
 		},
+		"@types/color-name": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+			"dev": true
+		},
 		"@types/glob": {
 			"version": "7.1.3",
 			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.3.tgz",
@@ -47,9 +53,9 @@
 			"dev": true
 		},
 		"@types/mocha": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.0.1.tgz",
-			"integrity": "sha512-TBZ6YdX7IZz4U9/mBoB8zCMRN1vXw8QdihRcZxD3I0Cv/r8XF8RggZ8WiXFws4aj5atzRR5hJrYer7g8nXwpnQ==",
+			"version": "8.0.3",
+			"resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.0.3.tgz",
+			"integrity": "sha512-vyxR57nv8NfcU0GZu8EUXZLTbCMupIUwy95LJ6lllN+JRPG25CwMHoB1q5xKh8YKhQnHYRAn4yW2yuHbf/5xgg==",
 			"dev": true
 		},
 		"@types/node": {
@@ -2384,9 +2390,9 @@
 			"dev": true
 		},
 		"is-callable": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
-			"integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+			"integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
 			"dev": true
 		},
 		"is-data-descriptor": {
@@ -2524,9 +2530,9 @@
 			}
 		},
 		"is-regex": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
-			"integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
+			"integrity": "sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==",
 			"dev": true,
 			"requires": {
 				"has-symbols": "^1.0.1"
@@ -2739,12 +2745,12 @@
 			}
 		},
 		"locate-path": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
-			"integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
 			"dev": true,
 			"requires": {
-				"p-locate": "^4.1.0"
+				"p-locate": "^5.0.0"
 			}
 		},
 		"lodash": {
@@ -2754,12 +2760,49 @@
 			"dev": true
 		},
 		"log-symbols": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-3.0.0.tgz",
-			"integrity": "sha512-dSkNGuI7iG3mfvDzUuYZyvk5dD9ocYCYzNU6CYDE6+Xqd+gwme6Z00NS3dUh8mq/73HaEtT7m6W+yUPtU6BZnQ==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.0.0.tgz",
+			"integrity": "sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==",
 			"dev": true,
 			"requires": {
-				"chalk": "^2.4.2"
+				"chalk": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"dev": true,
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
+					"integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"dev": true,
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+					"dev": true
+				}
 			}
 		},
 		"lower-case": {
@@ -2929,23 +2972,23 @@
 			}
 		},
 		"mocha": {
-			"version": "8.1.0",
-			"resolved": "https://registry.npmjs.org/mocha/-/mocha-8.1.0.tgz",
-			"integrity": "sha512-sI0gaI1I/jPVu3KFpnveWGadfe3JNBAENqgTUPgLZAUppu725zS2mrVztzAgIR8DUscuS4doEBTx9LATC+HSeA==",
+			"version": "8.1.3",
+			"resolved": "https://registry.npmjs.org/mocha/-/mocha-8.1.3.tgz",
+			"integrity": "sha512-ZbaYib4hT4PpF4bdSO2DohooKXIn4lDeiYqB+vTmCdr6l2woW0b6H3pf5x4sM5nwQMru9RvjjHYWVGltR50ZBw==",
 			"dev": true,
 			"requires": {
 				"ansi-colors": "4.1.1",
 				"browser-stdout": "1.3.1",
-				"chokidar": "3.3.1",
-				"debug": "3.2.6",
+				"chokidar": "3.4.2",
+				"debug": "4.1.1",
 				"diff": "4.0.2",
-				"escape-string-regexp": "1.0.5",
-				"find-up": "4.1.0",
+				"escape-string-regexp": "4.0.0",
+				"find-up": "5.0.0",
 				"glob": "7.1.6",
 				"growl": "1.10.5",
 				"he": "1.2.0",
-				"js-yaml": "3.13.1",
-				"log-symbols": "3.0.0",
+				"js-yaml": "3.14.0",
+				"log-symbols": "4.0.0",
 				"minimatch": "3.0.4",
 				"ms": "2.1.2",
 				"object.assign": "4.1.0",
@@ -3005,9 +3048,9 @@
 					"dev": true
 				},
 				"chokidar": {
-					"version": "3.3.1",
-					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.3.1.tgz",
-					"integrity": "sha512-4QYCEWOcK3OJrxwvyyAOxFuhpvOVCYkr33LPfFNBjAD/w3sEzWsp2BUOkI4l9bHvWioAd0rc6NlHUOEaWkTeqg==",
+					"version": "3.4.2",
+					"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.4.2.tgz",
+					"integrity": "sha512-IZHaDeBeI+sZJRX7lGcXsdzgvZqKv6sECqsbErJA4mHWfpRrD8B97kSFN4cQz6nGBGiuFia1MKR4d6c1o8Cv7A==",
 					"dev": true,
 					"requires": {
 						"anymatch": "~3.1.1",
@@ -3017,7 +3060,7 @@
 						"is-binary-path": "~2.1.0",
 						"is-glob": "~4.0.1",
 						"normalize-path": "~3.0.0",
-						"readdirp": "~3.3.0"
+						"readdirp": "~3.4.0"
 					}
 				},
 				"cliui": {
@@ -3031,6 +3074,21 @@
 						"wrap-ansi": "^5.1.0"
 					}
 				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"escape-string-regexp": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+					"dev": true
+				},
 				"fill-range": {
 					"version": "7.0.1",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -3041,12 +3099,12 @@
 					}
 				},
 				"find-up": {
-					"version": "4.1.0",
-					"resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-					"integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+					"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
 					"dev": true,
 					"requires": {
-						"locate-path": "^5.0.0",
+						"locate-path": "^6.0.0",
 						"path-exists": "^4.0.0"
 					}
 				},
@@ -3093,11 +3151,30 @@
 					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 					"dev": true
 				},
+				"js-yaml": {
+					"version": "3.14.0",
+					"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.0.tgz",
+					"integrity": "sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==",
+					"dev": true,
+					"requires": {
+						"argparse": "^1.0.7",
+						"esprima": "^4.0.0"
+					}
+				},
 				"normalize-path": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
 					"integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
 					"dev": true
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
+					}
 				},
 				"p-locate": {
 					"version": "3.0.0",
@@ -3115,12 +3192,12 @@
 					"dev": true
 				},
 				"readdirp": {
-					"version": "3.3.0",
-					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.3.0.tgz",
-					"integrity": "sha512-zz0pAkSPOXXm1viEwygWIPSPkcBYjW1xU5j/JBh5t9bGCJwa6f9+BJa6VaB2g+b55yVrmXzqkyLf4xaWYM0IkQ==",
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.4.0.tgz",
+					"integrity": "sha512-0xe001vZBnJEK+uKcj8qOhyAKPzIT+gStxWr3LCB0DwcXR5NZJ3IaC+yGnHCYzB/S7ov3m3EEbZI2zeNvX+hGQ==",
 					"dev": true,
 					"requires": {
-						"picomatch": "^2.0.7"
+						"picomatch": "^2.2.1"
 					}
 				},
 				"require-main-filename": {
@@ -3527,21 +3604,21 @@
 			}
 		},
 		"p-limit": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
-			"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.0.2.tgz",
+			"integrity": "sha512-iwqZSOoWIW+Ew4kAGUlN16J4M7OB3ysMLSZtnhmqx7njIHFPlxWBX8xo3lVTyFVq6mI/lL9qt2IsN1sHwaxJkg==",
 			"dev": true,
 			"requires": {
 				"p-try": "^2.0.0"
 			}
 		},
 		"p-locate": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
-			"integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
 			"dev": true,
 			"requires": {
-				"p-limit": "^2.2.0"
+				"p-limit": "^3.0.2"
 			}
 		},
 		"p-try": {
@@ -4556,9 +4633,9 @@
 			"dev": true
 		},
 		"typescript": {
-			"version": "3.9.7",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.7.tgz",
-			"integrity": "sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==",
+			"version": "4.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.3.tgz",
+			"integrity": "sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==",
 			"dev": true
 		},
 		"uc.micro": {
@@ -4774,9 +4851,9 @@
 			}
 		},
 		"vsce": {
-			"version": "1.79.5",
-			"resolved": "https://registry.npmjs.org/vsce/-/vsce-1.79.5.tgz",
-			"integrity": "sha512-KZFOthGwxWFwoGqwrkzfTfyCZGuniTofnJ1a/dCzQ2HP93u1UuCKrTQyGT+SuGHu8sNqdBYNe0hb9GC3qCN7fg==",
+			"version": "1.80.0",
+			"resolved": "https://registry.npmjs.org/vsce/-/vsce-1.80.0.tgz",
+			"integrity": "sha512-pnJT0LttCd5k1fJRsTOer8NvgesMYxLZYTUwuVWVOgONK9w+U5Yf32rtm4cX374TsHZbBwUr6ZFLP36wyDD8/g==",
 			"dev": true,
 			"requires": {
 				"azure-devops-node-api": "^7.2.0",
@@ -4964,6 +5041,15 @@
 					"requires": {
 						"p-locate": "^3.0.0",
 						"path-exists": "^3.0.0"
+					}
+				},
+				"p-limit": {
+					"version": "2.3.0",
+					"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.3.0.tgz",
+					"integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
+					"dev": true,
+					"requires": {
+						"p-try": "^2.0.0"
 					}
 				},
 				"p-locate": {

--- a/src/extension/package.json
+++ b/src/extension/package.json
@@ -11,7 +11,7 @@
     },
     "author": "Neo Global Development Seattle",
     "engines": {
-        "vscode": "^1.42.0"
+        "vscode": "^1.47.0"
     },
     "categories": [
         "Debuggers"
@@ -386,15 +386,15 @@
     },
     "devDependencies": {
         "@types/glob": "^7.1.3",
-        "@types/mocha": "^8.0.1",
+        "@types/mocha": "^8.0.3",
         "@types/node": "^12.8.1",
-        "@types/vscode": "^1.42.0",
+        "@types/vscode": "^1.47.0",
         "gulp": "4.0.2",
-        "mocha": "^8.1.0",
+        "mocha": "^8.1.3",
         "nerdbank-gitversioning": "^3.2.31",
         "tslint": "^6.1.3",
-        "typescript": "^3.9.7",
-        "vsce": "^1.79.5",
+        "typescript": "^4.0.3",
+        "vsce": "^1.80.0",
         "vscode-test": "^1.4.0"
     }
 }

--- a/src/extension/package.json
+++ b/src/extension/package.json
@@ -391,10 +391,10 @@
         "@types/vscode": "^1.47.0",
         "gulp": "4.0.2",
         "mocha": "^8.1.3",
-        "nerdbank-gitversioning": "^3.2.31",
+        "nerdbank-gitversioning": "^3.3.37",
         "tslint": "^6.1.3",
-        "typescript": "^4.0.3",
-        "vsce": "^1.80.0",
+        "typescript": "^4.0.5",
+        "vsce": "^1.81.1",
         "vscode-test": "^1.4.0"
     }
 }


### PR DESCRIPTION
NeoDebugger has special logic for launching the debug adapter via `dotnet run` when running in debug mode. VSCode recently introduced an [official mechanism](https://github.com/microsoft/vscode/issues/95926) to detect when it's running in dev/test/prod mode. This PR replaces the [recommended workaround](https://github.com/Microsoft/vscode/issues/10272) with the value passed via `vscode.ExtensionContext.extensionMode`