### PR TITLE
Adapt to Script Hash Identification Change

### DIFF
--- a/src/adapter3/DebugApplicationEngine.ExecutionContextAdapter.cs
+++ b/src/adapter3/DebugApplicationEngine.ExecutionContextAdapter.cs
@@ -14,9 +14,21 @@ namespace NeoDebug.Neo3
             private readonly ExecutionContext context;
             private readonly EvaluationStackAdapter evalStackAdapter;
 
-            public ExecutionContextAdapter(ExecutionContext context)
+            public ExecutionContextAdapter(ExecutionContext context, IDictionary<UInt160, UInt160> scriptIdMap)
             {
                 this.context = context;
+                this.ScriptIdentifier = context.GetScriptHash();
+
+                if (scriptIdMap.TryGetValue(this.ScriptIdentifier, out var scriptHash))
+                {
+                    this.ScriptHash = scriptHash;
+                }
+                else
+                {
+                    this.ScriptHash = Neo.SmartContract.Helper.ToScriptHash(context.Script);
+                    scriptIdMap[this.ScriptIdentifier] = this.ScriptHash;
+                }
+
                 evalStackAdapter = new EvaluationStackAdapter(context.EvaluationStack);
             }
 
@@ -34,7 +46,8 @@ namespace NeoDebug.Neo3
 
             public Script Script => context.Script;
 
-            public UInt160 ScriptHash => context.GetScriptHash();
+            public UInt160 ScriptIdentifier { get; }
+            public UInt160 ScriptHash { get; }
         }
 
     }

--- a/src/adapter3/DebugApplicationEngine.InvocationStackAdapter.cs
+++ b/src/adapter3/DebugApplicationEngine.InvocationStackAdapter.cs
@@ -24,7 +24,7 @@ namespace NeoDebug.Neo3
             {
                 foreach (var s in engine.InvocationStack)
                 {
-                    yield return new ExecutionContextAdapter(s);
+                    yield return new ExecutionContextAdapter(s, engine.scriptIdMap);
                 }
             }
 

--- a/src/adapter3/DebugApplicationEngine.cs
+++ b/src/adapter3/DebugApplicationEngine.cs
@@ -22,7 +22,6 @@ namespace NeoDebug.Neo3
     internal partial class DebugApplicationEngine : ApplicationEngine, IApplicationEngine
     {
         private readonly static IReadOnlyDictionary<uint, ServiceMethod> debugServices;
-        private readonly IDictionary<UInt160, UInt160> scriptIdMap = new Dictionary<UInt160, UInt160>();
 
         static DebugApplicationEngine()
         {
@@ -47,9 +46,9 @@ namespace NeoDebug.Neo3
         private readonly IReadOnlyDictionary<uint, UInt256> blockHashMap;
         private readonly EvaluationStackAdapter resultStackAdapter;
         private readonly InvocationStackAdapter invocationStackAdapter;
+        private readonly IDictionary<UInt160, UInt160> scriptIdMap = new Dictionary<UInt160, UInt160>();
 
-        // TODO: Use TestModeGas constant when https://github.com/neo-project/neo/pull/2084 is merged
-        public DebugApplicationEngine(IVerifiable container, StoreView storeView, Func<byte[], bool>? witnessChecker) : base(TriggerType.Application, container, storeView, 20_00000000)
+        public DebugApplicationEngine(IVerifiable container, StoreView storeView, Func<byte[], bool>? witnessChecker) : base(TriggerType.Application, container, storeView, TestModeGas)
         {
             this.witnessChecker = witnessChecker ?? CheckWitness;
             this.blockHashMap = storeView.Blocks.Find()
@@ -149,8 +148,8 @@ namespace NeoDebug.Neo3
             Debug.Assert(paramDescriptors.Count == 1);
 
             var indexOrHash = (byte[])engine.Convert(engine.Pop(), paramDescriptors[0]);
-            var hash = engine.GetBlockHash(indexOrHash);
 
+            var hash = engine.GetBlockHash(indexOrHash);
             if (hash is null) return StackItem.Null;
             Block block = engine.Snapshot.GetBlock(hash);
             if (block is null) return StackItem.Null;
@@ -167,7 +166,6 @@ namespace NeoDebug.Neo3
             var txIndex = (int)engine.Convert(engine.Pop(), paramDescriptors[1]);
 
             var hash = engine.GetBlockHash(blockIndexOrHash);
-
             if (hash is null) return StackItem.Null;
             var block = engine.Snapshot.Blocks.TryGet(hash);
             if (block is null) return StackItem.Null;
@@ -195,7 +193,7 @@ namespace NeoDebug.Neo3
                 }
             }
 
-            throw new ArgumentException();
+            return null;
         }
 
         public bool TryGetContract(UInt160 scriptHash, [MaybeNullWhen(false)] out Script script)

--- a/src/adapter3/DebugApplicationEngine.cs
+++ b/src/adapter3/DebugApplicationEngine.cs
@@ -22,6 +22,7 @@ namespace NeoDebug.Neo3
     internal partial class DebugApplicationEngine : ApplicationEngine, IApplicationEngine
     {
         private readonly static IReadOnlyDictionary<uint, ServiceMethod> debugServices;
+        private readonly IDictionary<UInt160, UInt160> scriptIdMap = new Dictionary<UInt160, UInt160>();
 
         static DebugApplicationEngine()
         {
@@ -213,6 +214,6 @@ namespace NeoDebug.Neo3
 
         IExecutionContext? IApplicationEngine.CurrentContext => CurrentContext == null
             ? null
-            : new ExecutionContextAdapter(CurrentContext);
+            : new ExecutionContextAdapter(CurrentContext, scriptIdMap);
     }
 }

--- a/src/adapter3/DebugApplicationEngine.cs
+++ b/src/adapter3/DebugApplicationEngine.cs
@@ -41,8 +41,8 @@ namespace NeoDebug.Neo3
             }
         }
 
-        public event EventHandler<(UInt160 scriptHash, string eventName, NeoArray state)>? DebugNotify;
-        public event EventHandler<(UInt160 scriptHash, string message)>? DebugLog;
+        public event EventHandler<(UInt160 scriptHash, string scriptName, string eventName, NeoArray state)>? DebugNotify;
+        public event EventHandler<(UInt160 scriptHash, string scriptName, string message)>? DebugLog;
         private readonly Func<byte[], bool> witnessChecker;
         private readonly IReadOnlyDictionary<uint, UInt256> blockHashMap;
         private readonly EvaluationStackAdapter resultStackAdapter;
@@ -72,17 +72,23 @@ namespace NeoDebug.Neo3
 
         private void OnNotify(object? sender, NotifyEventArgs args)
         {
+            var contract = Snapshot.Contracts.TryGet(args.ScriptHash);
+            var name = contract == null ? string.Empty : (contract.Manifest.Name ?? string.Empty);
+
             if (ReferenceEquals(sender, this))
             {
-                DebugNotify?.Invoke(sender, (args.ScriptHash, args.EventName, args.State));
+                DebugNotify?.Invoke(sender, (args.ScriptHash, name, args.EventName, args.State));
             }
         }
 
         private void OnLog(object? sender, LogEventArgs args)
         {
+            var contract = Snapshot.Contracts.TryGet(args.ScriptHash);
+            var name = contract == null ? string.Empty : (contract.Manifest.Name ?? string.Empty);
+
             if (ReferenceEquals(sender, this))
             {
-                DebugLog?.Invoke(sender, (args.ScriptHash, args.Message));
+                DebugLog?.Invoke(sender, (args.ScriptHash, name, args.Message));
             }
         }
 

--- a/src/adapter3/DebugSession.cs
+++ b/src/adapter3/DebugSession.cs
@@ -43,19 +43,19 @@ namespace NeoDebug.Neo3
             this.engine.DebugLog += OnLog;
         }
 
-        private void OnNotify(object? sender, (UInt160 scriptHash, string eventName, NeoArray state) args)
+        private void OnNotify(object? sender, (UInt160 scriptHash, string scriptName, string eventName, NeoArray state) args)
         {
             sendEvent(new OutputEvent()
             {
-                Output = $"Runtime.Notify: {args.scriptHash} {args.eventName} {args.state.ToResult()}\n",
+                Output = $"Runtime.Notify: {(string.IsNullOrEmpty(args.scriptName) ? args.scriptHash.ToString() : args.scriptName)} {args.eventName} {args.state.ToResult()}\n",
             });
         }
 
-        private void OnLog(object? sender, (UInt160 scriptHash, string message) args)
+        private void OnLog(object? sender, (UInt160 scriptHash, string scriptName, string message) args)
         {
             sendEvent(new OutputEvent()
             {
-                Output = $"Runtime.Log: {args.scriptHash} {args.message}\n",
+                Output = $"Runtime.Log: {(string.IsNullOrEmpty(args.scriptName) ? args.scriptHash.ToString() : args.scriptName)} {args.message}\n",
             });
         }
 

--- a/src/adapter3/IApplicationEngine.cs
+++ b/src/adapter3/IApplicationEngine.cs
@@ -11,8 +11,8 @@ namespace NeoDebug.Neo3
 {
     internal interface IApplicationEngine : IDisposable
     {
-        event EventHandler<(UInt160 scriptHash, string eventName, NeoArray state)>? DebugNotify;
-        event EventHandler<(UInt160 scriptHash, string message)>? DebugLog;
+        event EventHandler<(UInt160 scriptHash, string scriptName, string eventName, NeoArray state)>? DebugNotify;
+        event EventHandler<(UInt160 scriptHash, string scriptName, string message)>? DebugLog;
 
         bool CatchBlockOnStack();
 

--- a/src/adapter3/IExecutionContext.cs
+++ b/src/adapter3/IExecutionContext.cs
@@ -12,6 +12,7 @@ namespace NeoDebug.Neo3
     {
         Instruction CurrentInstruction { get; }
         int InstructionPointer { get; }
+        UInt160 ScriptIdentifier { get; }
         UInt160 ScriptHash { get; }
         Script Script { get; }
         IReadOnlyList<StackItem> EvaluationStack { get; }

--- a/src/adapter3/LaunchConfigParser.Invocations.cs
+++ b/src/adapter3/LaunchConfigParser.Invocations.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace NeoDebug.Neo3
 {
-    internal static partial class LaunchConfigParser
+    partial class LaunchConfigParser
     {
         public struct InvokeFileInvocation
         {

--- a/src/adapter3/LaunchConfigParser.cs
+++ b/src/adapter3/LaunchConfigParser.cs
@@ -102,9 +102,14 @@ namespace NeoDebug.Neo3
 
         IApplicationEngine CreateTraceEngine(string traceFilePath)
         {
-            throw new Exception();
-            // var contracts = ParseStoredContracts().Select(t => LoadContract(t.contractPath));
-            // return new TraceApplicationEngine(traceFilePath, contracts);
+            var contracts = new List<NefFile>();
+            var launchContractPath = config["program"].Value<string>() ?? throw new Exception("missing program config property");
+            var launchContract = LoadContract(launchContractPath);
+            contracts.Add(launchContract);
+
+            // TODO: load other contracts
+
+            return new TraceApplicationEngine(traceFilePath, contracts);
         }
 
         async Task<IApplicationEngine> CreateDebugEngineAsync(Invocation invocation)

--- a/src/adapter3/TraceApplicationEngine.ExecutionContextAdapter.cs
+++ b/src/adapter3/TraceApplicationEngine.ExecutionContextAdapter.cs
@@ -21,7 +21,7 @@ namespace NeoDebug.Neo3
                 {
                     Script = script;
                 }
-                else if (TryGetNativeContract(frame.ScriptHash, out script))
+                else if (TryGetNativeContract(frame.ScriptIdentifier, out script))
                 {
                     Script = script;
                 }
@@ -50,6 +50,7 @@ namespace NeoDebug.Neo3
 
             public int InstructionPointer => frame.InstructionPointer;
 
+            public UInt160 ScriptIdentifier => frame.ScriptIdentifier;
             public UInt160 ScriptHash => frame.ScriptHash;
 
             public Script Script { get; }

--- a/src/adapter3/TraceApplicationEngine.cs
+++ b/src/adapter3/TraceApplicationEngine.cs
@@ -95,13 +95,13 @@ namespace NeoDebug.Neo3
                 case NotifyRecord notify:
                     if (!stepBack)
                     {
-                        DebugNotify?.Invoke(this, (notify.ScriptHash, notify.EventName, new NeoArray(notify.State)));
+                        DebugNotify?.Invoke(this, (notify.ScriptHash, notify.ScriptName, notify.EventName, new NeoArray(notify.State)));
                     }
                     break;
                 case LogRecord log:
                     if (!stepBack)
                     {
-                        DebugLog?.Invoke(this, (log.ScriptHash, log.Message));
+                        DebugLog?.Invoke(this, (log.ScriptHash, log.ScriptName, log.Message));
                     }
                     break;
                 case ResultsRecord results:
@@ -120,8 +120,8 @@ namespace NeoDebug.Neo3
         public IExecutionContext? CurrentContext => InvocationStack.FirstOrDefault();
         public IReadOnlyList<StackItem> ResultStack { get; private set; } = new List<StackItem>();
         public Exception? FaultException { get; private set; }
-        public event EventHandler<(UInt160 scriptHash, string eventName, NeoArray state)>? DebugNotify;
-        public event EventHandler<(UInt160 scriptHash, string message)>? DebugLog;
+        public event EventHandler<(UInt160 scriptHash, string scriptName, string eventName, NeoArray state)>? DebugNotify;
+        public event EventHandler<(UInt160 scriptHash, string scriptName, string message)>? DebugLog;
 
         public bool CatchBlockOnStack() => stackFrames.Any(f => f.HasCatch);
 

--- a/src/adapter3/TraceApplicationEngine.cs
+++ b/src/adapter3/TraceApplicationEngine.cs
@@ -23,7 +23,8 @@ namespace NeoDebug.Neo3
 
         public TraceApplicationEngine(string traceFilePath, IEnumerable<NefFile> contracts)
         {
-            this.contracts = contracts.ToDictionary(c => c.ScriptHash, c => (Script)c.Script);
+            // TODO: probably need to capture more info in trace to make this work right
+            this.contracts = contracts.ToDictionary(c => Neo.SmartContract.Helper.ToScriptHash(c.Script), c => (Script)c.Script);
             traceFile = new TraceFile(traceFilePath, this.contracts);
 
             while (traceFile.TryGetNext(out var record))

--- a/src/adapter3/TraceApplicationEngine.cs
+++ b/src/adapter3/TraceApplicationEngine.cs
@@ -23,7 +23,6 @@ namespace NeoDebug.Neo3
 
         public TraceApplicationEngine(string traceFilePath, IEnumerable<NefFile> contracts)
         {
-            // TODO: probably need to capture more info in trace to make this work right
             this.contracts = contracts.ToDictionary(c => Neo.SmartContract.Helper.ToScriptHash(c.Script), c => (Script)c.Script);
             traceFile = new TraceFile(traceFilePath, this.contracts);
 

--- a/src/adapter3/neodebug-3-adapter.csproj
+++ b/src/adapter3/neodebug-3-adapter.csproj
@@ -20,10 +20,14 @@
     <PackageReference Include="Microsoft.VisualStudio.Shared.VsCodeDebugProtocol" Version="16.7.40526.2">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
-    <PackageReference Include="Neo.BlockchainToolkit3" Version="0.4.52-preview" />
+    <!-- <PackageReference Include="Neo.BlockchainToolkit3" Version="0.4.52-preview" /> -->
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Nito.Disposables" Version="2.2.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
     <PackageReference Include="System.Linq.Async" Version="4.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\lib-bctk\src\bctklib-3\bctklib-3.csproj" />
   </ItemGroup>
 </Project>

--- a/src/adapter3/neodebug-3-adapter.csproj
+++ b/src/adapter3/neodebug-3-adapter.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="Microsoft.VisualStudio.Shared.VsCodeDebugProtocol" Version="16.7.40526.2">
       <NoWarn>NU1701</NoWarn>
     </PackageReference>
-    <!-- <PackageReference Include="Neo.BlockchainToolkit3" Version="0.4.52-preview" /> -->
+    <PackageReference Include="Neo.BlockchainToolkit3" Version="0.4.56-preview" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="Nito.Disposables" Version="2.2.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
@@ -28,6 +28,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\..\..\lib-bctk\src\bctklib-3\bctklib-3.csproj" />
+    <!-- <ProjectReference Include="..\..\..\lib-bctk\src\bctklib-3\bctklib-3.csproj" /> -->
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This PR adapts neo debugger to changes introduced by https://github.com/neo-project/neo/pull/2044

In particular, this change adds a new `IExecutionContext.ScriptIdentifier` property. This property represents the script hash identifier generated when a contract is deployed to the blockchain. `IExecutionContext.ScriptHash` is the SHA 256 hash of the contract binary. Both are needed in neo debugger - the former is how contracts are identified by the contract execution engine and contract state table. The latter is used for mapping contracts to debugger information. 