### PR TITLE
Improve Nep17 debug experience

### DIFF
--- a/src/adapter3/DebugSession.cs
+++ b/src/adapter3/DebugSession.cs
@@ -404,9 +404,15 @@ namespace NeoDebug.Neo3
             {
                 if (engine.State == VMState.FAULT)
                 {
-                    var output = engine.FaultException == null
-                        ? "Engine State Faulted\n"
-                        : $"Engine State Fault: {engine.FaultException.Message}\n";
+                    var output = "Engine State Faulted\n";
+                    if (engine.FaultException != null)
+                    {
+                        output = $"Engine State Fault: {engine.FaultException.Message} [{engine.FaultException.GetType().Name}]\n";
+                        if (engine.FaultException.InnerException != null)
+                        {
+                            output += $"  Contract Exception: {engine.FaultException.InnerException.Message} [{engine.FaultException.InnerException.GetType().Name}]\n";
+                        }
+                    }
 
                     sendEvent(new OutputEvent()
                     {

--- a/src/adapter3/LaunchConfigParser.Invocations.cs
+++ b/src/adapter3/LaunchConfigParser.Invocations.cs
@@ -18,11 +18,13 @@ namespace NeoDebug.Neo3
 
         public struct LaunchInvocation
         {
+            public readonly string Contract;
             public readonly string Operation;
             public readonly JArray Args;
 
-            public LaunchInvocation(string operation, JArray args)
+            public LaunchInvocation(string contract, string operation, JArray args)
             {
+                Contract = contract;
                 Operation = operation;
                 Args = args;
             }
@@ -36,12 +38,15 @@ namespace NeoDebug.Neo3
                     return false;
                 }
 
-                var args = token["args"];
-                var array = args == null
-                    ? new JArray()
-                    : args is JArray ? (JArray)args : new JArray(args);
+                var contractJson = token["contract"];
+                var contract = contractJson == null ? string.Empty : contractJson.Value<string>();
 
-                invocation = new LaunchInvocation(operation, array);
+                var argsJson = token["args"];
+                var args = argsJson == null
+                    ? new JArray()
+                    : argsJson is JArray ? (JArray)argsJson : new JArray(argsJson);
+
+                invocation = new LaunchInvocation(contract, operation, args);
                 return true;
             }
         }

--- a/src/adapter3/LaunchConfigParser.cs
+++ b/src/adapter3/LaunchConfigParser.cs
@@ -165,7 +165,9 @@ namespace NeoDebug.Neo3
                 Witnesses = Array.Empty<Witness>()
             };
 
-            var engine = new DebugApplicationEngine(tx, new SnapshotView(store), witnessChecker);
+            var snapshot = new SnapshotView(store);
+            snapshot.PersistingBlock = new Block();
+            var engine = new DebugApplicationEngine(tx, snapshot, witnessChecker);
             engine.LoadScript(invokeScript);
             return engine;
 
@@ -335,6 +337,12 @@ namespace NeoDebug.Neo3
                 oracle => Task.FromResult<Script>(OracleResponse.FixedScript),
                 launch =>
                 {
+                    if (launch.Contract.Length > 0
+                        && contracts.TryGetValue(launch.Contract, out var hash))
+                    {
+                        scriptHash = hash;
+                    }
+
                     var args = paramParser.ParseParameters(launch.Args).ToArray();
                     using var builder = new ScriptBuilder();
                     builder.EmitAppCall(scriptHash, launch.Operation, args);

--- a/src/adapter3/LaunchConfigParser.cs
+++ b/src/adapter3/LaunchConfigParser.cs
@@ -338,7 +338,7 @@ namespace NeoDebug.Neo3
                 launch =>
                 {
                     if (launch.Contract.Length > 0
-                        && contracts.TryGetValue(launch.Contract, out var hash))
+                        && paramParser.TryLoadScriptHash(launch.Contract, out var hash))
                     {
                         scriptHash = hash;
                     }

--- a/src/extension/package.json
+++ b/src/extension/package.json
@@ -114,6 +114,9 @@
                                             "args"
                                         ],
                                         "properties": {
+                                            "contract": {
+                                                "type": "string"
+                                            },
                                             "operation": {
                                                 "type": "string"
                                             },


### PR DESCRIPTION
Two changes discovered while working on debugging Nep17 template:

* Enable launch configuration to specify contract to invoke by name. By default, debugger invokes the contract specified in `program` attribute. However, some scenarios are invoked on behalf of another contract. This change allows the launch configuration to specify a contract to invoke other than the default
* if available, include inner exception info in fault message