### PR TITLE
Update neo-debugger.debug description text

### DIFF
--- a/src/extension/package.json
+++ b/src/extension/package.json
@@ -54,7 +54,7 @@
                 "neo-debugger.debug": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Pass the --debug flag when launching the Neo Debugger server"
+                    "description": "Pass the --debug flag when launching the Neo Debugger server. Note, this setting is for developers contributing to the Neo Debugger extension. If you're *using* the Neo Debugger extension, setting this flag will cause the debugger to hang."
                 },
                 "neo-debugger.default-debug-view": {
                     "type": "string",

--- a/src/extension/package.json
+++ b/src/extension/package.json
@@ -54,7 +54,7 @@
                 "neo-debugger.debug": {
                     "type": "boolean",
                     "default": false,
-                    "description": "Pass the --debug flag when launching the Neo Debugger server. Note, this setting is for developers contributing to the Neo Debugger extension. If you're *using* the Neo Debugger extension, setting this flag will cause the debugger to hang."
+                    "markdownDescription": "Pass the `--debug` flag when launching the Neo Debugger server. Note, this setting is for developers who are _contributing_ to the Neo Debugger extension. If you're _using_ the Neo Debugger extension, this flag will **_cause the debugger to hang_**."
                 },
                 "neo-debugger.default-debug-view": {
                     "type": "string",


### PR DESCRIPTION
Updated neo-debugger.debug description to better disuade debugger users from setting the flag.

![image](https://user-images.githubusercontent.com/8965/124200487-54eb9780-da8a-11eb-9acf-e610d96bced6.png)
