### PR TITLE
Update Debug Adapter Protocol initialization code 

### DIFF
--- a/src/adapter3/DebugAdapter.cs
+++ b/src/adapter3/DebugAdapter.cs
@@ -28,7 +28,6 @@ namespace NeoDebug.Neo3
 
         private readonly DebugSessionFactory sessionFactory;
         private readonly Action<LogCategory, string> logger;
-        private readonly bool trace;
         private readonly DebugView defaultDebugView;
         private IDebugSession? session;
 
@@ -36,12 +35,10 @@ namespace NeoDebug.Neo3
                             System.IO.Stream @in,
                             System.IO.Stream @out,
                             Action<LogCategory, string>? logger,
-                            bool trace,
                             DebugView defaultDebugView)
         {
             this.sessionFactory = sessionFactory;
             this.logger = logger ?? ((_, __) => { });
-            this.trace = trace;
             this.defaultDebugView = defaultDebugView;
 
             InitializeProtocolClient(@in, @out);
@@ -68,7 +65,6 @@ namespace NeoDebug.Neo3
             {
                 SupportsEvaluateForHovers = true,
                 SupportsExceptionInfoRequest = true,
-                SupportsStepBack = trace,
                 ExceptionBreakpointFilters = new List<ExceptionBreakpointsFilter>
                 {
                     new ExceptionBreakpointsFilter(

--- a/src/adapter3/DebugAdapter.cs
+++ b/src/adapter3/DebugAdapter.cs
@@ -26,18 +26,15 @@ namespace NeoDebug.Neo3
             public string DebugView { get; set; } = string.Empty;
         }
 
-        private readonly DebugSessionFactory sessionFactory;
         private readonly Action<LogCategory, string> logger;
         private readonly DebugView defaultDebugView;
         private IDebugSession? session;
 
-        public DebugAdapter(DebugSessionFactory sessionFactory,
-                            System.IO.Stream @in,
+        public DebugAdapter(System.IO.Stream @in,
                             System.IO.Stream @out,
                             Action<LogCategory, string>? logger,
                             DebugView defaultDebugView)
         {
-            this.sessionFactory = sessionFactory;
             this.logger = logger ?? ((_, __) => { });
             this.defaultDebugView = defaultDebugView;
 
@@ -59,8 +56,6 @@ namespace NeoDebug.Neo3
 
         protected override InitializeResponse HandleInitializeRequest(InitializeArguments arguments)
         {
-            Protocol.SendEvent(new InitializedEvent());
-
             return new InitializeResponse()
             {
                 SupportsEvaluateForHovers = true,
@@ -83,27 +78,38 @@ namespace NeoDebug.Neo3
             };
         }
 
-        protected override LaunchResponse HandleLaunchRequest(LaunchArguments arguments)
+        protected override void HandleLaunchRequestAsync(IRequestResponder<LaunchArguments> responder)
         {
-            // since CreateDebugSession is an async method, we should be using HandleLaunchRequestAsync.
-            // However, using HandleLaunchRequestAsync causes VSCode to send setBreakpoints and
-            // threads request before receiving the launch response. 
-
-            try
+            if (session != null)
             {
-                if (session != null) throw new InvalidOperationException();
-
-                session = sessionFactory(arguments, Protocol.SendEvent, defaultDebugView)
-                    .GetAwaiter().GetResult();
-                session.Start();
-
-                return new LaunchResponse();
-            }
-            catch (Exception ex)
-            {
+                var ex = new InvalidOperationException();
                 Log(ex.Message, LogCategory.DebugAdapterOutput);
-                throw new ProtocolException(ex.Message, ex);
+                responder.SetError(new ProtocolException(ex.Message, ex));
+                return;
             }
+
+            LaunchConfigParser.CreateDebugSessionAsync(responder.Arguments, Protocol.SendEvent, defaultDebugView)
+                .ContinueWith(t => 
+                {
+                    if (t.IsCompletedSuccessfully)
+                    {
+                        session = t.Result;
+                        session.Start();
+                        Protocol.SendEvent(new InitializedEvent());
+                        responder.SetResponse(new LaunchResponse());
+                    }
+                    else
+                    {
+                        if (t.Exception != null)
+                        {
+                            responder.SetError(new ProtocolException(t.Exception.Message, t.Exception));
+                        }
+                        else
+                        {
+                            responder.SetError(new ProtocolException($"Unknown error in {nameof(LaunchConfigParser.CreateDebugSessionAsync)}"));
+                        }
+                    }
+                });
         }
 
         private void HandleDebugViewRequest(DebugViewArguments arguments)

--- a/src/adapter3/DebugApplicationEngine.cs
+++ b/src/adapter3/DebugApplicationEngine.cs
@@ -43,6 +43,8 @@ namespace NeoDebug.Neo3
             base.Dispose();
         }
 
+        bool IApplicationEngine.SupportsStepBack => false;
+
         private void OnNotify(object? sender, NotifyEventArgs args)
         {
             var name = GetContractName(args.ScriptHash);

--- a/src/adapter3/DebugSession.cs
+++ b/src/adapter3/DebugSession.cs
@@ -44,6 +44,14 @@ namespace NeoDebug.Neo3
 
             this.engine.DebugNotify += OnNotify;
             this.engine.DebugLog += OnLog;
+
+            if (engine.SupportsStepBack)
+            {
+                sendEvent(new CapabilitiesEvent 
+                { 
+                    Capabilities = new Capabilities { SupportsStepBack = true }
+                });
+            }
         }
 
         private void OnNotify(object? sender, (UInt160 scriptHash, string scriptName, string eventName, NeoArray state) args)

--- a/src/adapter3/IApplicationEngine.cs
+++ b/src/adapter3/IApplicationEngine.cs
@@ -21,6 +21,7 @@ namespace NeoDebug.Neo3
         bool TryGetContract(UInt160 scriptHash, [MaybeNullWhen(false)] out Script script);
         StorageContainerBase GetStorageContainer(UInt160 scriptHash);
 
+        bool SupportsStepBack { get; }
         byte AddressVersion { get; }
         IReadOnlyCollection<IExecutionContext> InvocationStack { get; }
         IExecutionContext? CurrentContext { get; }

--- a/src/adapter3/LaunchConfigParser.cs
+++ b/src/adapter3/LaunchConfigParser.cs
@@ -61,6 +61,13 @@ namespace NeoDebug.Neo3
 
             var debugInfoList = await LoadDebugInfosAsync(launchArguments.ConfigurationProperties, sourceFileMap).ToListAsync().ConfigureAwait(false);
             var engine = await CreateEngineAsync(launchArguments.ConfigurationProperties).ConfigureAwait(false);
+            if (engine is TraceApplicationEngine)
+            {
+                sendEvent(new CapabilitiesEvent 
+                { 
+                    Capabilities = new Capabilities { SupportsStepBack = true }
+                });
+            }
             return new DebugSession(engine, debugInfoList, returnTypes, sendEvent, defaultDebugView);
         }
 

--- a/src/adapter3/LaunchConfigParser.cs
+++ b/src/adapter3/LaunchConfigParser.cs
@@ -61,13 +61,6 @@ namespace NeoDebug.Neo3
 
             var debugInfoList = await LoadDebugInfosAsync(launchArguments.ConfigurationProperties, sourceFileMap).ToListAsync().ConfigureAwait(false);
             var engine = await CreateEngineAsync(launchArguments.ConfigurationProperties).ConfigureAwait(false);
-            if (engine is TraceApplicationEngine)
-            {
-                sendEvent(new CapabilitiesEvent 
-                { 
-                    Capabilities = new Capabilities { SupportsStepBack = true }
-                });
-            }
             return new DebugSession(engine, debugInfoList, returnTypes, sendEvent, defaultDebugView);
         }
 

--- a/src/adapter3/Program.cs
+++ b/src/adapter3/Program.cs
@@ -54,7 +54,6 @@ namespace NeoDebug.Neo3
                 throw new ArgumentException(nameof(DefaultDebugView));
 
             var adapter = new DebugAdapter(
-                LaunchConfigParser.CreateDebugSessionAsync,
                 Console.OpenStandardInput(),
                 Console.OpenStandardOutput(),
                 LogMessage,

--- a/src/adapter3/Program.cs
+++ b/src/adapter3/Program.cs
@@ -21,9 +21,6 @@ namespace NeoDebug.Neo3
         [Option("-v|--debug-view")]
         private string DefaultDebugView { get; } = string.Empty;
 
-        [Option]
-        private bool Trace { get; }
-
         public Program()
         {
             var neoDebugLogPath = Path.Combine(
@@ -61,7 +58,6 @@ namespace NeoDebug.Neo3
                 Console.OpenStandardInput(),
                 Console.OpenStandardOutput(),
                 LogMessage,
-                Trace,
                 defaultDebugView);
 
             adapter.Run();

--- a/src/adapter3/TraceApplicationEngine.cs
+++ b/src/adapter3/TraceApplicationEngine.cs
@@ -46,6 +46,8 @@ namespace NeoDebug.Neo3
             }
         }
 
+        bool IApplicationEngine.SupportsStepBack => true;
+
         public bool ExecuteNextInstruction()
         {
             while (traceFile.TryGetNext(out var record))

--- a/src/extension/src/extension.ts
+++ b/src/extension/src/extension.ts
@@ -297,10 +297,6 @@ class NeoContractDebugAdapterDescriptorFactory implements vscode.DebugAdapterDes
             args.push(defaultDebugView);
         }
 
-        if (session.configuration["invocation"]?.["trace-file"]) {
-            args.push("--trace");
-        }
-
         const options = session.workspaceFolder ? { cwd: session.workspaceFolder.uri.fsPath } : {};
         this.channel.appendLine(`launching ${cmd} ${args.join(' ')}`);
         this.channel.appendLine(`current directory ${options.cwd ?? 'missing'}`);


### PR DESCRIPTION
This PR updates and simplifies the initialization of the Neo N3 Debug Adapter

* SupportStepBack now enabled via CapabilitiesEvent rather than command line parameter
* DebugAdapter using HandleLaunchRequestAsync instead of HandleLaunchRequest
* use of LaunchConfigParser.CreateDebugSessionAsync now implemented directly in HandleLaunchRequestAsync instead of being passed in by a delegate
