### PR TITLE
support downloading debug adapter from github

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -15,7 +15,7 @@
             "outFiles": [
                 "${workspaceFolder}/src/extension/out/**/*.js"
             ],
-            "preLaunchTask": "build all"
+            // "preLaunchTask": "build all"
         },
         {
             "name": "Attach N3 Debug Adapter",

--- a/src/extension/.vscodeignore
+++ b/src/extension/.vscodeignore
@@ -9,3 +9,5 @@ vsc-extension-quickstart.md
 **/tslint.json
 **/*.map
 **/*.ts
+Neo.Debug2.Adapter.*.nupkg
+Neo.Debug3.Adapter.*.nupkg

--- a/src/extension/.vscodeignore
+++ b/src/extension/.vscodeignore
@@ -10,4 +10,3 @@ vsc-extension-quickstart.md
 **/*.map
 **/*.ts
 Neo.Debug2.Adapter.*.nupkg
-Neo.Debug3.Adapter.*.nupkg

--- a/src/extension/package-lock.json
+++ b/src/extension/package-lock.json
@@ -9,6 +9,7 @@
             "version": "0.0.0",
             "license": "MIT",
             "dependencies": {
+                "@octokit/rest": "^19.0.4",
                 "glob": "^8.0.3"
             },
             "devDependencies": {
@@ -48,6 +49,153 @@
                 "@babel/helper-validator-identifier": "^7.10.4",
                 "chalk": "^2.0.0",
                 "js-tokens": "^4.0.0"
+            }
+        },
+        "node_modules/@octokit/auth-token": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.1.tgz",
+            "integrity": "sha512-/USkK4cioY209wXRpund6HZzHo9GmjakpV9ycOkpMcMxMk7QVcVFVyCMtzvXYiHsB2crgDgrtNYSELYFBXhhaA==",
+            "dependencies": {
+                "@octokit/types": "^7.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@octokit/core": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.0.5.tgz",
+            "integrity": "sha512-4R3HeHTYVHCfzSAi0C6pbGXV8UDI5Rk+k3G7kLVNckswN9mvpOzW9oENfjfH3nEmzg8y3AmKmzs8Sg6pLCeOCA==",
+            "dependencies": {
+                "@octokit/auth-token": "^3.0.0",
+                "@octokit/graphql": "^5.0.0",
+                "@octokit/request": "^6.0.0",
+                "@octokit/request-error": "^3.0.0",
+                "@octokit/types": "^7.0.0",
+                "before-after-hook": "^2.2.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@octokit/endpoint": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.1.tgz",
+            "integrity": "sha512-/wTXAJwt0HzJ2IeE4kQXO+mBScfzyCkI0hMtkIaqyXd9zg76OpOfNQfHL9FlaxAV2RsNiOXZibVWloy8EexENg==",
+            "dependencies": {
+                "@octokit/types": "^7.0.0",
+                "is-plain-object": "^5.0.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@octokit/graphql": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.1.tgz",
+            "integrity": "sha512-sxmnewSwAixkP1TrLdE6yRG53eEhHhDTYUykUwdV9x8f91WcbhunIHk9x1PZLALdBZKRPUO2HRcm4kezZ79HoA==",
+            "dependencies": {
+                "@octokit/request": "^6.0.0",
+                "@octokit/types": "^7.0.0",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@octokit/openapi-types": {
+            "version": "13.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.0.1.tgz",
+            "integrity": "sha512-40U39YoFBhJhmkAg6gbJnh9U8aueJwCuiTW0mXY2pNl9/+E7dUxXiMPOrIUGT12XqLinroaXYA3FUiw3BMeNfg=="
+        },
+        "node_modules/@octokit/plugin-paginate-rest": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.0.0.tgz",
+            "integrity": "sha512-g4GJMt/7VDmIMMdQenN6bmsmRoZca1c7IxOdF2yMiMwQYrE2bmmypGQeQSD5rsaffsFMCUS7Br4pMVZamareYA==",
+            "dependencies": {
+                "@octokit/types": "^7.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=4"
+            }
+        },
+        "node_modules/@octokit/plugin-request-log": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+            "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+            "peerDependencies": {
+                "@octokit/core": ">=3"
+            }
+        },
+        "node_modules/@octokit/plugin-rest-endpoint-methods": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.3.0.tgz",
+            "integrity": "sha512-qEu2wn6E7hqluZwIEUnDxWROvKjov3zMIAi4H4d7cmKWNMeBprEXZzJe8pE5eStUYC1ysGhD0B7L6IeG1Rfb+g==",
+            "dependencies": {
+                "@octokit/types": "^7.0.0",
+                "deprecation": "^2.3.1"
+            },
+            "engines": {
+                "node": ">= 14"
+            },
+            "peerDependencies": {
+                "@octokit/core": ">=3"
+            }
+        },
+        "node_modules/@octokit/request": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.1.tgz",
+            "integrity": "sha512-gYKRCia3cpajRzDSU+3pt1q2OcuC6PK8PmFIyxZDWCzRXRSIBH8jXjFJ8ZceoygBIm0KsEUg4x1+XcYBz7dHPQ==",
+            "dependencies": {
+                "@octokit/endpoint": "^7.0.0",
+                "@octokit/request-error": "^3.0.0",
+                "@octokit/types": "^7.0.0",
+                "is-plain-object": "^5.0.0",
+                "node-fetch": "^2.6.7",
+                "universal-user-agent": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@octokit/request-error": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.1.tgz",
+            "integrity": "sha512-ym4Bp0HTP7F3VFssV88WD1ZyCIRoE8H35pXSKwLeMizcdZAYc/t6N9X9Yr9n6t3aG9IH75XDnZ6UeZph0vHMWQ==",
+            "dependencies": {
+                "@octokit/types": "^7.0.0",
+                "deprecation": "^2.0.0",
+                "once": "^1.4.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@octokit/rest": {
+            "version": "19.0.4",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.4.tgz",
+            "integrity": "sha512-LwG668+6lE8zlSYOfwPj4FxWdv/qFXYBpv79TWIQEpBLKA9D/IMcWsF/U9RGpA3YqMVDiTxpgVpEW3zTFfPFTA==",
+            "dependencies": {
+                "@octokit/core": "^4.0.0",
+                "@octokit/plugin-paginate-rest": "^4.0.0",
+                "@octokit/plugin-request-log": "^1.0.4",
+                "@octokit/plugin-rest-endpoint-methods": "^6.0.0"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/@octokit/types": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.0.0.tgz",
+            "integrity": "sha512-8uSDc66p6+wADn6lh6lA7I3ZTIapn7F/dfpsiDztVjEr6kkyKR3qPqa4lgEX92O/8iJoDeGcscKRXGAjCSR/zg==",
+            "dependencies": {
+                "@octokit/openapi-types": "^13.0.0"
             }
         },
         "node_modules/@types/glob": {
@@ -158,6 +306,11 @@
                     "url": "https://feross.org/support"
                 }
             ]
+        },
+        "node_modules/before-after-hook": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
+            "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
         },
         "node_modules/bl": {
             "version": "4.1.0",
@@ -452,6 +605,11 @@
             "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
             "dev": true
         },
+        "node_modules/deprecation": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+        },
         "node_modules/detect-libc": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
@@ -695,9 +853,9 @@
             }
         },
         "node_modules/has-symbols": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
             "dev": true,
             "engines": {
                 "node": ">= 0.4"
@@ -783,6 +941,14 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/is-plain-object": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+            "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -796,9 +962,9 @@
             "dev": true
         },
         "node_modules/js-yaml": {
-            "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-            "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+            "version": "3.14.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
             "dev": true,
             "dependencies": {
                 "argparse": "^1.0.7",
@@ -1035,6 +1201,25 @@
             "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
             "dev": true
         },
+        "node_modules/node-fetch": {
+            "version": "2.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+            "dependencies": {
+                "whatwg-url": "^5.0.0"
+            },
+            "engines": {
+                "node": "4.x || >=6.0.0"
+            },
+            "peerDependencies": {
+                "encoding": "^0.1.0"
+            },
+            "peerDependenciesMeta": {
+                "encoding": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/npmlog": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
@@ -1078,9 +1263,9 @@
             }
         },
         "node_modules/object-inspect": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-            "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+            "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
             "dev": true,
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -1498,6 +1683,11 @@
                 "node": ">=8.17.0"
             }
         },
+        "node_modules/tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
         "node_modules/tslib": {
             "version": "1.13.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
@@ -1624,6 +1814,11 @@
             "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
             "dev": true
         },
+        "node_modules/universal-user-agent": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+            "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+        },
         "node_modules/url-join": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
@@ -1709,6 +1904,20 @@
             },
             "engines": {
                 "node": ">=10"
+            }
+        },
+        "node_modules/webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "node_modules/whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "dependencies": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
             }
         },
         "node_modules/wide-align": {
@@ -1800,6 +2009,118 @@
                 "js-tokens": "^4.0.0"
             }
         },
+        "@octokit/auth-token": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-3.0.1.tgz",
+            "integrity": "sha512-/USkK4cioY209wXRpund6HZzHo9GmjakpV9ycOkpMcMxMk7QVcVFVyCMtzvXYiHsB2crgDgrtNYSELYFBXhhaA==",
+            "requires": {
+                "@octokit/types": "^7.0.0"
+            }
+        },
+        "@octokit/core": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@octokit/core/-/core-4.0.5.tgz",
+            "integrity": "sha512-4R3HeHTYVHCfzSAi0C6pbGXV8UDI5Rk+k3G7kLVNckswN9mvpOzW9oENfjfH3nEmzg8y3AmKmzs8Sg6pLCeOCA==",
+            "requires": {
+                "@octokit/auth-token": "^3.0.0",
+                "@octokit/graphql": "^5.0.0",
+                "@octokit/request": "^6.0.0",
+                "@octokit/request-error": "^3.0.0",
+                "@octokit/types": "^7.0.0",
+                "before-after-hook": "^2.2.0",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "@octokit/endpoint": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-7.0.1.tgz",
+            "integrity": "sha512-/wTXAJwt0HzJ2IeE4kQXO+mBScfzyCkI0hMtkIaqyXd9zg76OpOfNQfHL9FlaxAV2RsNiOXZibVWloy8EexENg==",
+            "requires": {
+                "@octokit/types": "^7.0.0",
+                "is-plain-object": "^5.0.0",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "@octokit/graphql": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-5.0.1.tgz",
+            "integrity": "sha512-sxmnewSwAixkP1TrLdE6yRG53eEhHhDTYUykUwdV9x8f91WcbhunIHk9x1PZLALdBZKRPUO2HRcm4kezZ79HoA==",
+            "requires": {
+                "@octokit/request": "^6.0.0",
+                "@octokit/types": "^7.0.0",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "@octokit/openapi-types": {
+            "version": "13.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-13.0.1.tgz",
+            "integrity": "sha512-40U39YoFBhJhmkAg6gbJnh9U8aueJwCuiTW0mXY2pNl9/+E7dUxXiMPOrIUGT12XqLinroaXYA3FUiw3BMeNfg=="
+        },
+        "@octokit/plugin-paginate-rest": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-4.0.0.tgz",
+            "integrity": "sha512-g4GJMt/7VDmIMMdQenN6bmsmRoZca1c7IxOdF2yMiMwQYrE2bmmypGQeQSD5rsaffsFMCUS7Br4pMVZamareYA==",
+            "requires": {
+                "@octokit/types": "^7.0.0"
+            }
+        },
+        "@octokit/plugin-request-log": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
+            "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
+            "requires": {}
+        },
+        "@octokit/plugin-rest-endpoint-methods": {
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-6.3.0.tgz",
+            "integrity": "sha512-qEu2wn6E7hqluZwIEUnDxWROvKjov3zMIAi4H4d7cmKWNMeBprEXZzJe8pE5eStUYC1ysGhD0B7L6IeG1Rfb+g==",
+            "requires": {
+                "@octokit/types": "^7.0.0",
+                "deprecation": "^2.3.1"
+            }
+        },
+        "@octokit/request": {
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request/-/request-6.2.1.tgz",
+            "integrity": "sha512-gYKRCia3cpajRzDSU+3pt1q2OcuC6PK8PmFIyxZDWCzRXRSIBH8jXjFJ8ZceoygBIm0KsEUg4x1+XcYBz7dHPQ==",
+            "requires": {
+                "@octokit/endpoint": "^7.0.0",
+                "@octokit/request-error": "^3.0.0",
+                "@octokit/types": "^7.0.0",
+                "is-plain-object": "^5.0.0",
+                "node-fetch": "^2.6.7",
+                "universal-user-agent": "^6.0.0"
+            }
+        },
+        "@octokit/request-error": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-3.0.1.tgz",
+            "integrity": "sha512-ym4Bp0HTP7F3VFssV88WD1ZyCIRoE8H35pXSKwLeMizcdZAYc/t6N9X9Yr9n6t3aG9IH75XDnZ6UeZph0vHMWQ==",
+            "requires": {
+                "@octokit/types": "^7.0.0",
+                "deprecation": "^2.0.0",
+                "once": "^1.4.0"
+            }
+        },
+        "@octokit/rest": {
+            "version": "19.0.4",
+            "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.4.tgz",
+            "integrity": "sha512-LwG668+6lE8zlSYOfwPj4FxWdv/qFXYBpv79TWIQEpBLKA9D/IMcWsF/U9RGpA3YqMVDiTxpgVpEW3zTFfPFTA==",
+            "requires": {
+                "@octokit/core": "^4.0.0",
+                "@octokit/plugin-paginate-rest": "^4.0.0",
+                "@octokit/plugin-request-log": "^1.0.4",
+                "@octokit/plugin-rest-endpoint-methods": "^6.0.0"
+            }
+        },
+        "@octokit/types": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/@octokit/types/-/types-7.0.0.tgz",
+            "integrity": "sha512-8uSDc66p6+wADn6lh6lA7I3ZTIapn7F/dfpsiDztVjEr6kkyKR3qPqa4lgEX92O/8iJoDeGcscKRXGAjCSR/zg==",
+            "requires": {
+                "@octokit/openapi-types": "^13.0.0"
+            }
+        },
         "@types/glob": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
@@ -1888,6 +2209,11 @@
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
             "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
             "dev": true
+        },
+        "before-after-hook": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.2.tgz",
+            "integrity": "sha512-3pZEU3NT5BFUo/AD5ERPWOgQOCZITni6iavr5AUw5AUwQjMlI0kzu5btnyD39AF0gUEsDPwJT+oY1ORBJijPjQ=="
         },
         "bl": {
             "version": "4.1.0",
@@ -2128,6 +2454,11 @@
             "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
             "dev": true
         },
+        "deprecation": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+            "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ=="
+        },
         "detect-libc": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
@@ -2315,9 +2646,9 @@
             "dev": true
         },
         "has-symbols": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.1.tgz",
-            "integrity": "sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+            "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
             "dev": true
         },
         "has-unicode": {
@@ -2373,6 +2704,11 @@
                 "number-is-nan": "^1.0.0"
             }
         },
+        "is-plain-object": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+            "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+        },
         "isarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -2386,9 +2722,9 @@
             "dev": true
         },
         "js-yaml": {
-            "version": "3.13.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.13.1.tgz",
-            "integrity": "sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==",
+            "version": "3.14.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+            "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
             "dev": true,
             "requires": {
                 "argparse": "^1.0.7",
@@ -2586,6 +2922,14 @@
             "integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
             "dev": true
         },
+        "node-fetch": {
+            "version": "2.6.7",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+            "requires": {
+                "whatwg-url": "^5.0.0"
+            }
+        },
         "npmlog": {
             "version": "4.1.2",
             "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
@@ -2620,9 +2964,9 @@
             "dev": true
         },
         "object-inspect": {
-            "version": "1.11.0",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.11.0.tgz",
-            "integrity": "sha512-jp7ikS6Sd3GxQfZJPyH3cjcbJF6GZPClgdV+EFygjFLQ5FmW/dRUnTd9PQ9k0JhoNDabWFbpF1yCdSWCC6gexg==",
+            "version": "1.12.2",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
+            "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
             "dev": true
         },
         "once": {
@@ -2955,6 +3299,11 @@
                 "rimraf": "^3.0.0"
             }
         },
+        "tr46": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+            "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
         "tslib": {
             "version": "1.13.0",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.13.0.tgz",
@@ -3051,6 +3400,11 @@
             "integrity": "sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==",
             "dev": true
         },
+        "universal-user-agent": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.0.tgz",
+            "integrity": "sha512-isyNax3wXoKaulPDZWHQqbmIx1k2tb9fb3GGDBRxCscfYV2Ch7WxPArBsFEG8s/safwXTT7H4QGhaIkTp9447w=="
+        },
         "url-join": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
@@ -3120,6 +3474,20 @@
                         "lru-cache": "^6.0.0"
                     }
                 }
+            }
+        },
+        "webidl-conversions": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+            "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+            "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+            "requires": {
+                "tr46": "~0.0.3",
+                "webidl-conversions": "^3.0.0"
             }
         },
         "wide-align": {

--- a/src/extension/package.json
+++ b/src/extension/package.json
@@ -31,7 +31,7 @@
     ],
     "badges": [
         {
-            "url":  "https://github.com/neo-project/neo-debugger/actions/workflows/build-vscode.yml/badge.svg",
+            "url": "https://github.com/neo-project/neo-debugger/actions/workflows/build-vscode.yml/badge.svg",
             "href": "https://github.com/neo-project/neo-debugger/actions",
             "description": "Build Status"
         }
@@ -535,6 +535,7 @@
         "package-local": "npm run pack-adapters-local && vsce package"
     },
     "dependencies": {
+        "@octokit/rest": "^19.0.4",
         "glob": "^8.0.3"
     },
     "devDependencies": {

--- a/src/extension/package.json
+++ b/src/extension/package.json
@@ -53,7 +53,7 @@
                 "neo-debugger.debug": {
                     "type": "boolean",
                     "default": false,
-                    "markdownDescription": "Pass the `--debug` flag when launching the Neo Debugger server. Note, this setting is for developers who are _contributing_ to the Neo Debugger extension. If you're _using_ the Neo Debugger extension, this flag will **_cause the debugger to hang_**."
+                    "markdownDescription": "Pass the `--debug` flag when launching the Neo debug adapter. Note, this setting is for developers who are _contributing_ to the Neo Debugger extension. If you're _using_ the Neo Debugger extension, this flag will **_cause the debugger to hang_**."
                 },
                 "neo-debugger.default-debug-view": {
                     "type": "string",
@@ -67,7 +67,12 @@
                 "neo-debugger.debug-adapter": {
                     "type": "array",
                     "items": "string",
-                    "description": "Path to the Neo Debugger server"
+                    "description": "Path to the Neo debug adapter executable"
+                },
+                "neo-debugger.adapter-project": {
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Use debug adapter source project when debugging extension"
                 }
             }
         },

--- a/src/extension/src/extension.ts
+++ b/src/extension/src/extension.ts
@@ -11,6 +11,103 @@ import * as _glob from 'glob';
 import * as https from 'https';
 import { Octokit } from "@octokit/rest";
 
+interface GithubReleaseAsset {
+    url: string;
+    browser_download_url: string;
+    id: number;
+    node_id: string;
+    name: string;
+    label: string | null;
+    state: "uploaded" | "open";
+    content_type: string;
+    size: number;
+    download_count: number;
+    created_at: string;
+    updated_at: string;
+    uploader: {
+        name?: string | null | undefined;
+        email?: string | null | undefined;
+        login: string;
+        id: number;
+        node_id: string;
+        avatar_url: string;
+        gravatar_id: string | null;
+        url: string;
+        html_url: string;
+        followers_url: string;
+        following_url: string;
+        gists_url: string;
+        starred_url: string;
+        subscriptions_url: string;
+        organizations_url: string;
+        repos_url: string;
+        events_url: string;
+        received_events_url: string;
+        type: string;
+        site_admin: boolean;
+        starred_at?: string | undefined;
+    } | null;
+}
+
+interface GithubRelease {
+    url: string;
+    html_url: string;
+    assets_url: string;
+    upload_url: string;
+    tarball_url: string | null;
+    zipball_url: string | null;
+    id: number;
+    node_id: string;
+    tag_name: string;
+    target_commitish: string;
+    name: string | null;
+    body?: string | null | undefined;
+    draft: boolean;
+    prerelease: boolean;
+    created_at: string;
+    published_at: string | null;
+    author: {
+        name?: string | null | undefined;
+        email?: string | null | undefined;
+        login: string;
+        id: number;
+        node_id: string;
+        avatar_url: string;
+        gravatar_id: string | null;
+        url: string;
+        html_url: string;
+        followers_url: string;
+        following_url: string;
+        gists_url: string;
+        starred_url: string;
+        subscriptions_url: string;
+        organizations_url: string;
+        repos_url: string;
+        events_url: string;
+        received_events_url: string;
+        type: string;
+        site_admin: boolean;
+        starred_at?: string | undefined;
+    };
+    assets: GithubReleaseAsset[];
+    body_html?: string | undefined;
+    body_text?: string | undefined;
+    mentions_count?: number | undefined;
+    discussion_url?: string | undefined;
+    reactions?: {
+        url: string;
+        total_count: number;
+        "+1": number;
+        "-1": number;
+        laugh: number;
+        confused: number;
+        heart: number;
+        hooray: number;
+        eyes: number;
+        rocket: number;
+    } | undefined;
+}
+
 // lifted from https://github.com/sindresorhus/slash
 function slash(path: string) {
     const isExtendedLengthPath = /^\\\\\?\\/.test(path);
@@ -63,26 +160,33 @@ function glob(pattern: string, options: _glob.IOptions = {}): Promise<string[]> 
     });
 }
 
-function downloadFile(url: string, path: string): Promise<void> {
-    return new Promise((resolve, reject) => {
 
+function downloadFile(url: string, path: string, onData: (length: number) => boolean) {
+    return new Promise<void>((resolve, reject) => {
         const request = https.get(url, (res) => {
             const statusCode = res.statusCode;
 
             if (statusCode === 200) {
 
                 const stream = createWriteStream(path, { flags: 'wx' });
-                res.on('end', () => {
-                    stream.end();
-                    resolve();
-                })
+                res
+                    .on('data', (c:Buffer) => {
+                        const cancel = onData(c.length);
+                        if (cancel) {
+                            reject(new Error("user canceled"));
+                        }
+                    })
+                    .on('end', () => {
+                        stream.end();
+                        resolve();
+                    })
                     .on('error', e => {
                         stream.destroy();
                         unlink(path, () => reject(e));
                     })
                     .pipe(stream);
             } else if (statusCode === 301 || statusCode === 302) {
-                downloadFile(res.headers.location!, path).then(() => resolve());
+                downloadFile(res.headers.location!, path, onData ).then(() => resolve());
             } else {
                 reject(new Error(`downloadFile failed ${res.statusCode}`));
             }
@@ -90,6 +194,24 @@ function downloadFile(url: string, path: string): Promise<void> {
 
         request.on('error', e => { unlink(path, () => reject(e)) });
     });
+
+}
+
+function downloadAsset(asset: GithubReleaseAsset, path: string, url?: string) {
+    return vscode.window.withProgress({
+        location: vscode.ProgressLocation.Notification,
+        title: `Downloading ${asset.name}`,
+        cancellable: true
+    }, (progress, token) => {
+        let total = 0;
+        return downloadFile(asset.browser_download_url, path, length => {
+            total += length;
+            const increment = total / asset.size 
+            const message = `${total} of ${asset.size} downloaded`;
+            progress.report({ message });
+            return token.isCancellationRequested;
+        })
+    })
 }
 
 // this method is called when your extension is activated
@@ -158,16 +280,6 @@ class NeoContractDebugConfigurationProvider implements vscode.DebugConfiguration
     }
 }
 
-
-
-
-
-
-
-
-
-
-
 class NeoContractDebugAdapterDescriptorFactory implements vscode.DebugAdapterDescriptorFactory {
 
     private readonly extension: vscode.Extension<any>;
@@ -202,8 +314,8 @@ class NeoContractDebugAdapterDescriptorFactory implements vscode.DebugAdapterDes
         }
 
         const options = session.workspaceFolder ? { cwd: session.workspaceFolder.uri.fsPath } : {};
-        this.channel.appendLine(`launching ${cmd} ${args.join(' ')}`);
-        this.channel.appendLine(`current directory ${options.cwd ?? 'missing'}`);
+        this.channel.appendLine(`Launching debug adapter "${cmd} ${args.join(' ')}"`);
+        this.channel.appendLine(`  Current directory "${options.cwd ?? 'missing'}"`);
         return new vscode.DebugAdapterExecutable(cmd, args, options);
     }
 
@@ -220,13 +332,13 @@ class NeoContractDebugAdapterDescriptorFactory implements vscode.DebugAdapterDes
 
         // get path to where debug adapter package gets installed 
         const packageId = getAdapterPackageId(program);
-        const installedAdapterPath = this.getInstalledAdapterPath(packageId);
+        const installedAdapterPath = resolve(this.extensionPath, packageId, this.getAssemblyName(packageId));
 
         // if the adapter is found at the expected installation location, use it
         if (await checkFileExists(installedAdapterPath)) {
             return { cmd: installedAdapterPath, args: [] };
         } else {
-            this.channel.appendLine(`${packageId} not installed at ${installedAdapterPath}`)
+            this.channel.appendLine(`${packageId} not found at ${installedAdapterPath}`)
         }
 
         // if the debug adapter package is available locally, install it
@@ -246,66 +358,14 @@ class NeoContractDebugAdapterDescriptorFactory implements vscode.DebugAdapterDes
             await fs.rm(adapterPackagePath);
             return { cmd: installedAdapterPath, args: [] };
         } else {
-            this.channel.appendLine(`${packageId} package not available at ${adapterPackagePath}`)
+            this.channel.appendLine(`${packageId} package not found in extension path ${this.extensionPath}`)
         }
-
-        // if the debug adapter package is not available locally, check to see if it can be
-        // downloaded from github
-        const version = this.extension.packageJSON.version;
-        const asset = await getAdapterPackageReleaseAsset(version, packageId);
-        if (asset) {
-            const tempDir = await fs.mkdtemp(resolve(os.tmpdir(), `${packageId}-`));
-            const tempPath = resolve(tempDir, asset.name);
-
-            this.channel.appendLine(`downloading ${asset.browser_download_url} to ${tempDir}`)
-            // await downloadFile(asset.browser_download_url, tempPath);
-            const stat = await fs.stat(tempPath);
-            if (stat.size === 0) throw new Error(`download failed`);
-
-            this.channel.appendLine(`installing ${packageId}.${version} from ${tempDir}`)
-            await this.installAdapter(packageId, version, tempDir);
-            if (await checkFileExists(installedAdapterPath)) {
-                await fs.rm(tempDir, { recursive: true, force: true });
-                return { cmd: installedAdapterPath, args: [] };
-            }
-
-            await fs.rm(tempDir, { recursive: true, force: true });
-        }
-        // if (release) {
-
-        //     // TODO: initiate package download automatically, but provide cancellation mechanism
-        //     const downloadResponse = await vscode.window.showInformationMessage(
-        //         `${packageId} package cannot be found locally. Download version ${version} from GitHub?`,
-        //         "Yes", "No");
-
-        //     if (downloadResponse === 'Yes') {
-        //         const asset = release.assets.find(a => {
-        //             return a.name.startsWith(packageId) && a.name.endsWith(".nupkg");
-        //         })
-
-        //         if (asset) {
-
-        //             const tempDir = await fs.mkdtemp(resolve(os.tmpdir(), `${packageId}-`));
-        //             const tempPath = resolve(tempDir, asset.name);
-
-        //             this.channel.appendLine(`downloading ${asset.browser_download_url} to ${tempDir}`)
-        //             await downloadFile(asset.browser_download_url, tempPath);
-        //             const stat = await fs.stat(tempPath);
-        //             if (stat.size === 0) throw new Error(`download failed`);
-        //             this.channel.appendLine(`installing ${packageId}.${version} from ${tempDir}`)
-
-        //             await this.installAdapter(packageId, version, tempDir);
-        //             if (await checkFileExists(installedAdapterPath)) {
-        //                 await fs.rm(tempDir, { recursive: true, force: true });
-        //                 return { cmd: installedAdapterPath, args: [] };
-        //             }
-        //         }
-        //     }
-        // }
 
         // if the extension is in development mode (i.e. the debugger extension is being debugged),
         // look for the debug adapter in the relevant adapter source directory
-        if (this.extensionMode === vscode.ExtensionMode.Development) {
+        if (this.extensionMode === vscode.ExtensionMode.Development
+            && (config.get<boolean>("adapter-project") ?? true)
+        ) {
             // if there's a compiled version of the adapter, use it
             const adapterProjectExePath = this.getAdapterProjectExePath(packageId);
             if (await checkFileExists(adapterProjectExePath)) {
@@ -317,6 +377,29 @@ class NeoContractDebugAdapterDescriptorFactory implements vscode.DebugAdapterDes
                 cmd: "dotnet",
                 args: ["run", "--project", this.getAdapterProjectPath(packageId), "--"]
             };
+        }
+
+        // if the debug adapter package is not available locally, check to see if it can be
+        // downloaded from github
+        const version = this.extension.packageJSON.version;
+        const asset = await getAdapterPackageReleaseAsset(version, packageId);
+        if (asset) {
+
+            const tempDir = await fs.mkdtemp(resolve(os.tmpdir(), `${packageId}-`));
+            const tempPath = resolve(tempDir, asset.name);
+
+            this.channel.appendLine(`downloading ${asset.browser_download_url} to ${tempDir}`)
+            await downloadAsset(asset, tempPath);
+            const stat = await fs.stat(tempPath);
+            if (stat.size === 0) throw new Error(`download failed`);
+
+            this.channel.appendLine(`installing ${packageId}.${version} from ${tempDir}`)
+            await this.installAdapter(packageId, version, tempDir);
+            if (await checkFileExists(installedAdapterPath)) {
+                this.channel.appendLine(`removing ${tempDir}`)
+                await fs.rm(tempDir, { recursive: true, force: true });
+                return { cmd: installedAdapterPath, args: [] };
+            }
         }
 
         throw new Error(`cannot locate ${packageId} debug adapter`);
@@ -332,15 +415,15 @@ class NeoContractDebugAdapterDescriptorFactory implements vscode.DebugAdapterDes
             }
         }
 
-        async function getAdapterPackageReleaseAsset(version: string, packageId: string) {
+        async function getAdapterPackageReleaseAsset(version: string, packageId: string): Promise<GithubReleaseAsset | undefined> {
             const release = await getAdapterPackageRelease(version);
             return release?.assets.find(asset => {
-                return asset.name.startsWith(packageId) 
+                return asset.name.startsWith(packageId)
                     && asset.name.endsWith('.nupkg')
             });
         }
 
-        async function getAdapterPackageRelease(version: string) {
+        async function getAdapterPackageRelease(version: string): Promise<GithubRelease | undefined> {
             try {
                 const octokit = new Octokit();
                 const release = await octokit.rest.repos.getReleaseByTag({
@@ -356,26 +439,7 @@ class NeoContractDebugAdapterDescriptorFactory implements vscode.DebugAdapterDes
                 return undefined;
             }
         }
-
-
-        // function getAdapterProjectInfo(program: string): { folderName: string; framework: string; } {
-        //     switch (extname(program)) {
-        //         case '.nef':
-        //             return {
-        //                 folderName: 'adapter3',
-        //                 framework: "net6.0"
-        //             };
-        //         case '.avm':
-        //             return {
-        //                 folderName: 'adapter1',
-        //                 framework: "netcoreapp3.1"
-        //             };
-        //         default:
-        //             throw new Error(`Unexpected Neo contract extension {ext}`);
-        //     }
-        // }
     }
-
 
     private getAdapterProjectPath(packageId: string): string {
         const srcDirectoryPath = resolve(this.extensionPath, "..");
@@ -391,36 +455,38 @@ class NeoContractDebugAdapterDescriptorFactory implements vscode.DebugAdapterDes
 
     private getAdapterProjectExePath(packageId: string): string {
         const adapterProjectPath = this.getAdapterProjectPath(packageId);
-        const adapterFileName = basename(this.getInstalledAdapterPath(packageId));
+        const segments = [adapterProjectPath, "bin", "Debug"];
+
         switch (packageId) {
             case 'Neo.Debug3.Adapter':
-                return resolve(adapterProjectPath, "bin", "Debug", "net6.0", adapterFileName);
+                segments.push("net6.0");
+                break;
             case 'Neo.Debug2.Adapter':
-                return resolve(adapterProjectPath, "bin", "Debug", "netcoreapp3.1", adapterFileName);
+                segments.push("netcoreapp3.1");
+                break;
             default:
                 throw new Error(`Unexpected adapter package ${packageId}`);
         }
-    }
 
-
-    private getInstalledAdapterPath(packageId: string): string {
-        return resolve(this.extensionPath, packageId, this.getAssemblyName(packageId));
+        segments.push(this.getAssemblyName(packageId));
+        return resolve(...segments);
     }
 
     private getAssemblyName(packageId: string) {
 
+        let path: string | undefined = undefined;
         switch (packageId) {
             case 'Neo.Debug3.Adapter':
-                return addExeOnWindows('neodebug-3-adapter');
+                path = 'neodebug-3-adapter';
+                break;
             case 'Neo.Debug2.Adapter':
-                return addExeOnWindows('neodebug-2-adapter');
+                path = 'neodebug-2-adapter';
+                break;
             default:
                 throw new Error(`Unexpected adapter package ${packageId}`);
         }
 
-        function addExeOnWindows(path: string) {
-            return os.platform() === "win32" ? `${path}.exe` : path;
-        }
+        return os.platform() === "win32" ? `${path}.exe` : path;
     }
 
     private async getExtensionAdapterPackagePath(packageId: string) {
@@ -437,24 +503,11 @@ class NeoContractDebugAdapterDescriptorFactory implements vscode.DebugAdapterDes
         // return matches.length === 1 ? matches[0] : undefined;
     }
 
-    // private async installAdapterPackage(adapterPackagePath: string, packageId: string) {
-    //     this.channel.appendLine(`Installing ${basename(adapterPackagePath)} package`);
-    //     const base = basename(adapterPackagePath, ".nupkg");
-    //     const version = base.startsWith(`${packageId}.`) ? base.substring(packageId.length + 1) : undefined;
-    //     if (!version) { throw new Error(`could not determine package version of ${adapterPackagePath}`) }
-
-    //     const commandLine = `dotnet tool install ${packageId} --version ${version} --tool-path ./${packageId} --add-source .`;
-    //     this.channel.appendLine(`  executing \"${commandLine}\"`);
-    //     await execChildProcess(commandLine, this.extensionPath);
-    //     this.channel.appendLine(`  deleting \"${basename(adapterPackagePath)}\"`);
-    //     await deleteFile(adapterPackagePath);
-    // }
-
     private async installAdapter(packageId: string, version: string, sourceDir?: string) {
         sourceDir ??= '.';
         const toolPath = resolve(this.extensionPath, packageId);
         const commandLine = `dotnet tool install ${packageId} --version ${version} --tool-path ${toolPath} --add-source ${sourceDir}`;
-        this.channel.appendLine(`  executing \"${commandLine}\"`);
+        this.channel.appendLine(`Installing ${packageId} via \"${commandLine}\"`);
         await execChildProcess(commandLine, this.extensionPath);
     }
 

--- a/src/extension/src/extension.ts
+++ b/src/extension/src/extension.ts
@@ -11,6 +11,9 @@ import * as _glob from 'glob';
 import * as https from 'https';
 import { Octokit } from "@octokit/rest";
 
+const OWNER = 'neo-project';
+const REPO = 'neo-debugger';
+
 interface GithubReleaseAsset {
     url: string;
     browser_download_url: string;
@@ -427,8 +430,8 @@ class NeoContractDebugAdapterDescriptorFactory implements vscode.DebugAdapterDes
             try {
                 const octokit = new Octokit();
                 const release = await octokit.rest.repos.getReleaseByTag({
-                    owner: 'neo-project',
-                    repo: 'neo-debugger',
+                    owner: OWNER,
+                    repo: REPO,
                     tag: version
                 });
                 if (release.status < 200 || release.status > 299) {
@@ -442,15 +445,16 @@ class NeoContractDebugAdapterDescriptorFactory implements vscode.DebugAdapterDes
     }
 
     private getAdapterProjectPath(packageId: string): string {
-        const srcDirectoryPath = resolve(this.extensionPath, "..");
+        const segments = [this.extensionPath, ".."];
         switch (packageId) {
             case 'Neo.Debug3.Adapter':
-                return resolve(srcDirectoryPath, 'adapter3');
+                segments.push('adapter3'); break;
             case 'Neo.Debug2.Adapter':
-                return resolve(srcDirectoryPath, 'adapter2');
+                segments.push('adapter2'); break;
             default:
                 throw new Error(`Unexpected adapter package ${packageId}`);
         }
+        return resolve(...segments);
     }
 
     private getAdapterProjectExePath(packageId: string): string {
@@ -474,7 +478,7 @@ class NeoContractDebugAdapterDescriptorFactory implements vscode.DebugAdapterDes
 
     private getAssemblyName(packageId: string) {
 
-        let path: string | undefined = undefined;
+        let path: string;
         switch (packageId) {
             case 'Neo.Debug3.Adapter':
                 path = 'neodebug-3-adapter';


### PR DESCRIPTION
THis allows us to exclude the neo2 adapter from the VSIX file. We will continue to include the Neo3 adapter in the vsix

fixes #157