### PR TITLE
Include more information to VSCode launch

### DIFF
--- a/src/extension/package.json
+++ b/src/extension/package.json
@@ -475,7 +475,7 @@
                             "request": "launch",
                             "program": "${workspaceFolder}",
                             "invocation": {
-                                "opration": "<insert operation here>",
+                                "operation": "<insert operation here>",
                                 "args": []
                             },
                             "storage": [],

--- a/src/extension/package.json
+++ b/src/extension/package.json
@@ -475,9 +475,12 @@
                             "request": "launch",
                             "program": "${workspaceFolder}",
                             "invocation": {
+                                "opration": "<insert operation here>",
                                 "args": []
                             },
-                            "storage": []
+                            "storage": [],
+                            "signers": [],
+                            "stored-contracts": []
                         }
                     }
                 ]

--- a/src/extension/src/extension.ts
+++ b/src/extension/src/extension.ts
@@ -240,7 +240,7 @@ class NeoContractDebugConfigurationProvider implements vscode.DebugConfiguration
 
         function createConfig(programPath: string | undefined = undefined): vscode.DebugConfiguration {
             var fs = require('fs');
-            const neoxpConfig: string = folder ? fs.readdirSync(folder.uri.fsPath).find(function (x: string) {
+            const neoxpConfig: string | undefined = folder ? fs.readdirSync(folder.uri.fsPath).find(function (x: string) {
                 return x.endsWith(".neo-express")
             }) : undefined;
 
@@ -248,7 +248,7 @@ class NeoContractDebugConfigurationProvider implements vscode.DebugConfiguration
                 name: programPath ? path.basename(programPath) : "Neo Contract",
                 type: "neo-contract",
                 request: "launch",
-                "neo-express": folder
+                "neo-express": neoxpConfig && folder
                     ? slash(path.join("${workspaceFolder}", neoxpConfig))
                     : "${workspaceFolder}/<insert path to neo express config here>",
                 program: programPath && folder

--- a/src/extension/src/extension.ts
+++ b/src/extension/src/extension.ts
@@ -239,20 +239,28 @@ class NeoContractDebugConfigurationProvider implements vscode.DebugConfiguration
     public async provideDebugConfigurations(folder: vscode.WorkspaceFolder | undefined, token?: vscode.CancellationToken): Promise<vscode.DebugConfiguration[]> {
 
         function createConfig(programPath: string | undefined = undefined): vscode.DebugConfiguration {
+            var fs = require('fs');
+            const neoxpConfig: string = folder ? fs.readdirSync(folder.uri.fsPath).find(function (x: string) {
+                return x.endsWith(".neo-express")
+            }) : undefined;
+
             return {
                 name: programPath ? path.basename(programPath) : "Neo Contract",
                 type: "neo-contract",
                 request: "launch",
+                "neo-express": folder
+                    ? slash(path.join("${workspaceFolder}", neoxpConfig))
+                    : "${workspaceFolder}/<insert path to neo express config here>",
                 program: programPath && folder
                     ? slash(path.join("${workspaceFolder}", path.relative(folder.uri.fsPath, programPath)))
                     : "${workspaceFolder}/<insert path to contract here>",
                 invocation: {
-                    operation: (programPath ? path.extname(programPath) : "") === ".nef"
-                        ? "<insert operation here>"
-                        : undefined,
+                    operation: "<insert operation here>",
                     args: [],
                 },
-                storage: []
+                storage: [],
+                signers: [],
+                "stored-contracts": []
             };
         }
 


### PR DESCRIPTION
Included more information to the launch neo contract object on the snippet.
There's a lot we can setup on launch to debug contracts that's not easy for the user to find out, even in the debugger documentation, as passing a specific neo-express config file to run the debugging or setup accounts to sign and debug the execution.

Also fixed the snippet that incorrectly generated a configuration without `operation` in the `invocation` object (which causes the execution to fail)